### PR TITLE
Use different base for final Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN make build
 
 
 
-FROM golang:1.14.4-alpine3.12
+FROM alpine:3.12
 
 RUN addgroup -S ably && adduser -S ably -G ably
 


### PR DESCRIPTION
This reduces the size of the container.

Before:
```bash
$ docker images | grep ably-boomer
ably-boomer                        latest                   bd20917f90ff    5 seconds ago    384MB
```

After:
```bash
$ docker images | grep ably-boomer
ably-boomer                        latest                   a58d5f5970df    3 seconds ago    19.8MB
```