### PR TITLE
Move ticker creation to after delay

### DIFF
--- a/ably/personal_task.go
+++ b/ably/personal_task.go
@@ -86,9 +86,6 @@ func personalTask(testConfig TestConfig) {
 		}
 	}
 
-	ticker := time.NewTicker(time.Duration(testConfig.PublishInterval) * time.Second)
-	defer ticker.Stop()
-
 	publishClient, err := newAblyClient(testConfig)
 	if err != nil {
 		boomer.RecordFailure("ably", "publish", 0, err.Error())
@@ -99,6 +96,9 @@ func personalTask(testConfig TestConfig) {
 	channel := publishClient.Channels.Get(channelName)
 
 	randomDelay()
+
+	ticker := time.NewTicker(time.Duration(testConfig.PublishInterval) * time.Second)
+	defer ticker.Stop()
 
 	for {
 		select {


### PR DESCRIPTION
The ticker should begin immediately on creation so the random delay has no effect unless it's called before the ticker is created. We see this causing bursts of message published over a 1s window instead of across the 60s random delay.