### PR TITLE
Add option to write cpu profile pprof

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ Variable | Description | Default | Required
 `ABLY_PUBLISHER` | If `true`, the worker will publish messages to the channels. If `false`, the worker will subscribe to the channels. Only used for `sharded` type tests. | `false` | no
 `ABLY_NUM_CHANNELS` | The number of channels a worker could subscribe to. A channel will be chosen at random. Only used for `sharded` type tests. | `64` | no
 
+## Performance Options
+
+The test can be configured to debug performance. Options are set through environment variables.
+
+Variable | Description | Default | Required
+--- | --- | --- | ---
+`PERF_CPU_PROFILE` | The file path to write the pprof cpu profile | n/a | no
 
 ## Build
 

--- a/ably/main.go
+++ b/ably/main.go
@@ -1,6 +1,10 @@
 package main
 
 import (
+	"log"
+	"os"
+	"runtime/pprof"
+
 	"github.com/ably-forks/boomer"
 )
 
@@ -25,6 +29,15 @@ func main() {
 	task := &boomer.Task{
 		Name: testConfig.TestType,
 		Fn:   fn,
+	}
+
+	if testConfig.CPUProfile != "" {
+		f, err := os.Create(testConfig.CPUProfile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		pprof.StartCPUProfile(f)
+		defer pprof.StopCPUProfile()
 	}
 
 	boomer.Run(task)

--- a/ably/test_config.go
+++ b/ably/test_config.go
@@ -7,6 +7,7 @@ import (
 )
 
 const DefaultChannelName = "test_channel"
+const DefaultCPUProfile = ""
 const DefaultPublishInterval = "10"
 const DefaultNumSubscriptions = "2"
 const DefaultMessageDataLength = "2000"
@@ -18,6 +19,7 @@ type TestConfig struct {
 	Env               string
 	ApiKey            string
 	ChannelName       string
+	CPUProfile        string
 	PublishInterval   int
 	NumSubscriptions  int
 	MessageDataLength int
@@ -31,6 +33,7 @@ func newTestConfig() TestConfig {
 		Env:               ablyEnv(),
 		ApiKey:            ablyApiKey(),
 		ChannelName:       ablyChannelName(),
+		CPUProfile:        ablyCPUProfile(),
 		PublishInterval:   ablyPublishInterval(),
 		NumSubscriptions:  ablyNumSubscriptions(),
 		MessageDataLength: ablyMessageDataLength(),
@@ -89,6 +92,10 @@ func ablyApiKey() string {
 
 func ablyChannelName() string {
 	return getEnvWithDefault("ABLY_CHANNEL_NAME", DefaultChannelName)
+}
+
+func ablyCPUProfile() string {
+	return getEnvWithDefault("ABLY_CPU_PROFILE", DefaultCPUProfile)
 }
 
 func ablyPublishInterval() int {

--- a/ably/test_config.go
+++ b/ably/test_config.go
@@ -7,24 +7,24 @@ import (
 )
 
 const DefaultChannelName = "test_channel"
-const DefaultCPUProfile = ""
 const DefaultPublishInterval = "10"
 const DefaultNumSubscriptions = "2"
 const DefaultMessageDataLength = "2000"
 const DefaultPublisher = "false"
 const DefaultNumChannels = "64"
+const DefaultCPUProfile = ""
 
 type TestConfig struct {
 	TestType          string
 	Env               string
 	ApiKey            string
 	ChannelName       string
-	CPUProfile        string
 	PublishInterval   int
 	NumSubscriptions  int
 	MessageDataLength int
 	Publisher         bool
 	NumChannels       int
+	CPUProfile        string
 }
 
 func newTestConfig() TestConfig {
@@ -33,12 +33,12 @@ func newTestConfig() TestConfig {
 		Env:               ablyEnv(),
 		ApiKey:            ablyApiKey(),
 		ChannelName:       ablyChannelName(),
-		CPUProfile:        ablyCPUProfile(),
 		PublishInterval:   ablyPublishInterval(),
 		NumSubscriptions:  ablyNumSubscriptions(),
 		MessageDataLength: ablyMessageDataLength(),
 		Publisher:         ablyPublisher(),
 		NumChannels:       ablyNumChannels(),
+		CPUProfile:        ablyCPUProfile(),
 	}
 }
 
@@ -94,10 +94,6 @@ func ablyChannelName() string {
 	return getEnvWithDefault("ABLY_CHANNEL_NAME", DefaultChannelName)
 }
 
-func ablyCPUProfile() string {
-	return getEnvWithDefault("ABLY_CPU_PROFILE", DefaultCPUProfile)
-}
-
 func ablyPublishInterval() int {
 	value := getEnvWithDefault("ABLY_PUBLISH_INTERVAL", DefaultPublishInterval)
 
@@ -132,4 +128,8 @@ func ablyMessageDataLength() int {
 	}
 
 	return n
+}
+
+func ablyCPUProfile() string {
+	return getEnvWithDefault("PERF_CPU_PROFILE", DefaultCPUProfile)
 }

--- a/ably/test_config_test.go
+++ b/ably/test_config_test.go
@@ -58,6 +58,7 @@ func TestNewTestConfig(t *testing.T) {
 		apiKey := "key"
 
 		defaultChannelName := "test_channel"
+		defaultCPUProfile := ""
 		defaultPublishInterval := 10
 		defaultNumSubscriptions := 2
 		defaultMessageDataLength := 2000
@@ -85,6 +86,10 @@ func TestNewTestConfig(t *testing.T) {
 			t.Errorf("ChannelName was incorrect, got: %s, wanted: %s.", testConfig.ChannelName, defaultChannelName)
 		}
 
+		if testConfig.CPUProfile != defaultCPUProfile {
+			t.Errorf("CPUProfile was incorrect, got: %s, wanted: %s.", testConfig.CPUProfile, defaultCPUProfile)
+		}
+
 		if testConfig.PublishInterval != defaultPublishInterval {
 			t.Errorf("PublishInterval was incorrect, got: %d, wanted: %d.", testConfig.PublishInterval, defaultPublishInterval)
 		}
@@ -103,6 +108,7 @@ func TestNewTestConfig(t *testing.T) {
 		env := "loadtest"
 		apiKey := "key"
 		channelName := "different-ably-channel"
+		cpuProfile := "/var/log/cpuprofile.pprof"
 		publishInterval := 60
 		numSubscriptions := 31250
 		messageDataLength := 9001
@@ -111,6 +117,7 @@ func TestNewTestConfig(t *testing.T) {
 		os.Setenv("ABLY_ENV", env)
 		os.Setenv("ABLY_API_KEY", apiKey)
 		os.Setenv("ABLY_CHANNEL_NAME", channelName)
+		os.Setenv("ABLY_CPU_PROFILE", cpuProfile)
 		os.Setenv("ABLY_PUBLISH_INTERVAL", strconv.Itoa(publishInterval))
 		os.Setenv("ABLY_NUM_SUBSCRIPTIONS", strconv.Itoa(numSubscriptions))
 		os.Setenv("ABLY_MSG_DATA_LENGTH", strconv.Itoa(messageDataLength))
@@ -132,6 +139,10 @@ func TestNewTestConfig(t *testing.T) {
 
 		if testConfig.ChannelName != channelName {
 			t.Errorf("ChannelName was incorrect, got: %s, wanted: %s.", testConfig.ChannelName, channelName)
+		}
+
+		if testConfig.CPUProfile != cpuProfile {
+			t.Errorf("CPUProfile was incorrect, got: %s, wanted: %s.", testConfig.CPUProfile, cpuProfile)
 		}
 
 		if testConfig.PublishInterval != publishInterval {

--- a/ably/test_config_test.go
+++ b/ably/test_config_test.go
@@ -14,6 +14,8 @@ func unsetEnv() {
 	os.Unsetenv("ABLY_PUBLISH_INTERVAL")
 	os.Unsetenv("ABLY_NUM_SUBSCRIPTIONS")
 	os.Unsetenv("ABLY_MSG_DATA_LENGTH")
+
+	os.Unsetenv("PERF_CPU_PROFILE")
 }
 
 func assertPanic(t *testing.T, f func() TestConfig) {
@@ -117,10 +119,10 @@ func TestNewTestConfig(t *testing.T) {
 		os.Setenv("ABLY_ENV", env)
 		os.Setenv("ABLY_API_KEY", apiKey)
 		os.Setenv("ABLY_CHANNEL_NAME", channelName)
-		os.Setenv("ABLY_CPU_PROFILE", cpuProfile)
 		os.Setenv("ABLY_PUBLISH_INTERVAL", strconv.Itoa(publishInterval))
 		os.Setenv("ABLY_NUM_SUBSCRIPTIONS", strconv.Itoa(numSubscriptions))
 		os.Setenv("ABLY_MSG_DATA_LENGTH", strconv.Itoa(messageDataLength))
+		os.Setenv("PERF_CPU_PROFILE", cpuProfile)
 		defer unsetEnv()
 
 		testConfig := newTestConfig()
@@ -141,10 +143,6 @@ func TestNewTestConfig(t *testing.T) {
 			t.Errorf("ChannelName was incorrect, got: %s, wanted: %s.", testConfig.ChannelName, channelName)
 		}
 
-		if testConfig.CPUProfile != cpuProfile {
-			t.Errorf("CPUProfile was incorrect, got: %s, wanted: %s.", testConfig.CPUProfile, cpuProfile)
-		}
-
 		if testConfig.PublishInterval != publishInterval {
 			t.Errorf("PublishInterval was incorrect, got: %d, wanted: %d.", testConfig.PublishInterval, publishInterval)
 		}
@@ -155,6 +153,10 @@ func TestNewTestConfig(t *testing.T) {
 
 		if testConfig.MessageDataLength != messageDataLength {
 			t.Errorf("MessageDataLength was incorrect, got: %d, wanted: %d.", testConfig.MessageDataLength, messageDataLength)
+		}
+
+		if testConfig.CPUProfile != cpuProfile {
+			t.Errorf("CPUProfile was incorrect, got: %s, wanted: %s.", testConfig.CPUProfile, cpuProfile)
 		}
 	})
 }


### PR DESCRIPTION
I figured since the performance of the load tester can have a material impact on the reported latency, it would be worth having the capability to take a cpu profile of it. Some of the go tooling does a similar thing with a `-pprof` flag so the performance of the tool can be inspected.

I didn't add this to the table of options in the README because it isn't really a configuration parameter for the test run itself. I could just read the env directly for this option if you think that would be better, rather than adding it to the test_config?