### PR TITLE
Use golint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode/
+bin/
 coverage/
 *.out
 *.test

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,17 @@
 DOCKER_IMAGE_TAG=latest
 
+# install shared tools to local bin directory
+BIN = $(CURDIR)/bin
+$(BIN):
+	@mkdir -p $@
+$(BIN)/%: | $(BIN)
+	@tmp=$$(mktemp -d); \
+		env GO111MODULE=off GOPATH=$$tmp GOBIN=$(BIN) go get $(PACKAGE) \
+		|| ret=$$?; \
+		rm -rf $$tmp ; exit $$ret
+
+$(BIN)/golint: PACKAGE=golang.org/x/lint/golint
+
 image:
 	DOCKER_BUILDKIT=1 docker build -t ablyrealtime/ably-boomer:$(DOCKER_IMAGE_TAG) .
 
@@ -10,16 +22,19 @@ build:
 	go vet ./ably
 	go build -o ably-boomer ./...
 
-cover:
+cover: lint
 	mkdir -p ./coverage
 	go test -covermode=atomic -coverprofile=coverage/coverage.out ./ably ./ably/perf
 	go tool cover -html=./coverage/coverage.out -o=./coverage/coverage.html
 
+GOLINT = $(BIN)/golint
+lint: | $(GOLINT)
+	$(GOLINT) -set_exit_status ./ably/...
 
-test:
-	go test ./ably ./ably/perf
+test: fmt lint
+	go test ./ably/...
 
 fmt:
-	go fmt ./ably
+	go fmt ./ably/...
 
 .PHONY: image push build test fmt

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ build:
 
 cover: lint
 	mkdir -p ./coverage
-	go test -covermode=atomic -coverprofile=coverage/coverage.out ./ably ./ably/perf
+	go test -covermode=atomic -coverprofile=coverage/coverage.out ./ably/...
 	go tool cover -html=./coverage/coverage.out -o=./coverage/coverage.html
 
 GOLINT = $(BIN)/golint

--- a/ably/ably_client.go
+++ b/ably/ably_client.go
@@ -5,7 +5,7 @@ import (
 )
 
 func newAblyClient(testConfig TestConfig) (*ably.RealtimeClient, error) {
-	options := ably.NewClientOptions(testConfig.ApiKey)
+	options := ably.NewClientOptions(testConfig.APIKey)
 	options.Environment = testConfig.Env
 
 	return ably.NewRealtimeClient(options)

--- a/ably/sharded_task.go
+++ b/ably/sharded_task.go
@@ -14,7 +14,7 @@ func generateChannelName(testConfig TestConfig, number int) string {
 	return "sharded-test-channel-" + strconv.Itoa(number%testConfig.NumChannels)
 }
 
-func publishOnInterval(testConfig TestConfig, ctx context.Context, channel *ably.RealtimeChannel, delay int) {
+func publishOnInterval(ctx context.Context, testConfig TestConfig, channel *ably.RealtimeChannel, delay int) {
 	log.Println("Delaying publish to", channel.Name, "for", delay+testConfig.PublishInterval, "seconds")
 	time.Sleep(time.Duration(delay) * time.Second)
 
@@ -61,7 +61,7 @@ func shardedPublisherTask(testConfig TestConfig) {
 
 		delay := i % testConfig.PublishInterval
 
-		go publishOnInterval(testConfig, ctx, channel, delay)
+		go publishOnInterval(ctx, testConfig, channel, delay)
 	}
 
 	<-ctx.Done()
@@ -116,9 +116,9 @@ func curryShardedTask(testConfig TestConfig) func() {
 		return func() {
 			shardedPublisherTask(testConfig)
 		}
-	} else {
-		return func() {
-			shardedSubscriberTask(testConfig)
-		}
+	}
+
+	return func() {
+		shardedSubscriberTask(testConfig)
 	}
 }

--- a/ably/test_config.go
+++ b/ably/test_config.go
@@ -6,17 +6,29 @@ import (
 	"strings"
 )
 
+// DefaultChannelName defines the channel name used by default in test runs
 const DefaultChannelName = "test_channel"
+
+// DefaultPublishInterval defines the default time between publishing message
 const DefaultPublishInterval = "10"
+
+// DefaultNumSubscriptions defines the default number of subscibers in test runs
 const DefaultNumSubscriptions = "2"
+
+// DefaultMessageDataLength defines the default size of messages in test runs
 const DefaultMessageDataLength = "2000"
+
+// DefaultPublisher defines if the test run should publish by default
 const DefaultPublisher = "false"
+
+// DefaultNumChannels defines the default number of channels used in test runs
 const DefaultNumChannels = "64"
 
+// TestConfig defines the configuration for a specific test run
 type TestConfig struct {
 	TestType          string
 	Env               string
-	ApiKey            string
+	APIKey            string
 	ChannelName       string
 	PublishInterval   int
 	NumSubscriptions  int
@@ -29,7 +41,7 @@ func newTestConfig() TestConfig {
 	return TestConfig{
 		TestType:          ablyTestType(),
 		Env:               ablyEnv(),
-		ApiKey:            ablyApiKey(),
+		APIKey:            ablyAPIKey(),
 		ChannelName:       ablyChannelName(),
 		PublishInterval:   ablyPublishInterval(),
 		NumSubscriptions:  ablyNumSubscriptions(),
@@ -83,7 +95,7 @@ func ablyEnv() string {
 	return getEnv("ABLY_ENV")
 }
 
-func ablyApiKey() string {
+func ablyAPIKey() string {
 	return getEnv("ABLY_API_KEY")
 }
 

--- a/ably/test_config_test.go
+++ b/ably/test_config_test.go
@@ -77,8 +77,8 @@ func TestNewTestConfig(t *testing.T) {
 			t.Errorf("Env was incorrect, got: %s, wanted: %s.", testConfig.Env, env)
 		}
 
-		if testConfig.ApiKey != apiKey {
-			t.Errorf("ApiKey was incorrect, got: %s, wanted: %s.", testConfig.ApiKey, apiKey)
+		if testConfig.APIKey != apiKey {
+			t.Errorf("ApiKey was incorrect, got: %s, wanted: %s.", testConfig.APIKey, apiKey)
 		}
 
 		if testConfig.ChannelName != defaultChannelName {
@@ -126,8 +126,8 @@ func TestNewTestConfig(t *testing.T) {
 			t.Errorf("Env was incorrect, got: %s, wanted: %s.", testConfig.Env, env)
 		}
 
-		if testConfig.ApiKey != apiKey {
-			t.Errorf("ApiKey was incorrect, got: %s, wanted: %s.", testConfig.ApiKey, apiKey)
+		if testConfig.APIKey != apiKey {
+			t.Errorf("ApiKey was incorrect, got: %s, wanted: %s.", testConfig.APIKey, apiKey)
 		}
 
 		if testConfig.ChannelName != channelName {


### PR DESCRIPTION
I think using golint is a good idea. I've added a make target for golint, updated the tests to use it and fixed the lint issues that are currently raised by it. Notably there were.

  - Context should always be the first param
  - Api should be spelt API
  - All exported tokens must have comments