### PR TITLE
Add perf histogram

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,4 +37,4 @@ test: fmt lint
 fmt:
 	go fmt ./ably/...
 
-.PHONY: image push build test fmt
+.PHONY: image push build cover lint test fmt

--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ The test can be configured to debug performance. Options are set through environ
 Variable | Description | Default | Required
 --- | --- | --- | ---
 `PERF_CPU_PROFILE_DIR` | The directorty path to write the pprof cpu profile | n/a | no
-`PERF_CPU_S3_BUCKET` | The name of the s3 bucket to upload pprof data to | n/a | no
+`PERF_CPU_PROFILE_S3_BUCKET` | The name of the s3 bucket to upload pprof data to | n/a | no
+`PERF_HISTOGRAM_DIR` | The directorty path to write the latency histogram data | n/a | no
+`PERF_HISTOGRAM_S3_BUCKET` | The name of the s3 bucket to upload latency histogram data to | n/a | no
 
 If uploading data to s3, the s3 client is configured through the default environment as per the
 [s3 client documentation](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html).

--- a/ably/fanout_task.go
+++ b/ably/fanout_task.go
@@ -9,11 +9,11 @@ import (
 	"github.com/ably/ably-boomer/ably/perf"
 )
 
-func fanOutTask(testConfig TestConfig, perf *perf.Reporter) {
+func fanOutTask(testConfig TestConfig, l perf.LocustReporter) {
 	client, err := newAblyClient(testConfig)
 
 	if err != nil {
-		perf.RecordFailure("ably", "subscribe", 0, err.Error())
+		l.RecordFailure("ably", "subscribe", 0, err.Error())
 		return
 	}
 	defer client.Close()
@@ -23,7 +23,7 @@ func fanOutTask(testConfig TestConfig, perf *perf.Reporter) {
 
 	sub, err := channel.Subscribe()
 	if err != nil {
-		perf.RecordFailure("ably", "subscribe", 0, err.Error())
+		l.RecordFailure("ably", "subscribe", 0, err.Error())
 		return
 	}
 	defer sub.Close()
@@ -34,7 +34,7 @@ func fanOutTask(testConfig TestConfig, perf *perf.Reporter) {
 	boomer.Events.Subscribe("boomer:stop", cancel)
 
 	errorChannel := make(chan error)
-	go reportSubscriptionToLocust(ctx, perf, sub, client.Connection, errorChannel)
+	go reportSubscriptionToLocust(ctx, l, sub, client.Connection, errorChannel)
 
 	select {
 	case err := <-errorChannel:
@@ -47,13 +47,13 @@ func fanOutTask(testConfig TestConfig, perf *perf.Reporter) {
 	}
 }
 
-func curryFanOutTask(testConfig TestConfig, perf *perf.Reporter) func() {
+func curryFanOutTask(testConfig TestConfig, l perf.LocustReporter) func() {
 	log.Println("Test Type: FanOut")
 	log.Println("Ably Env:", testConfig.Env)
 	log.Println("Channel Name:", testConfig.ChannelName)
 
 	return func() {
-		fanOutTask(testConfig, perf)
+		fanOutTask(testConfig, l)
 	}
 }
 

--- a/ably/main.go
+++ b/ably/main.go
@@ -7,14 +7,14 @@ import (
 	"github.com/ably/ably-boomer/ably/perf"
 )
 
-func taskFn(testConfig TestConfig, perf *perf.Reporter) func() {
+func taskFn(testConfig TestConfig, locust perf.LocustReporter) func() {
 	switch testConfig.TestType {
 	case "fanout":
-		return curryFanOutTask(testConfig, perf)
+		return curryFanOutTask(testConfig, locust)
 	case "personal":
-		return curryPersonalTask(testConfig, perf)
+		return curryPersonalTask(testConfig, locust)
 	case "sharded":
-		return curryShardedTask(testConfig, perf)
+		return curryShardedTask(testConfig, locust)
 	default:
 		panic("Unknown test type: '" + testConfig.TestType + "'")
 	}
@@ -22,7 +22,7 @@ func taskFn(testConfig TestConfig, perf *perf.Reporter) func() {
 
 func main() {
 	testConfig := newTestConfig()
-	perf := perf.NewReporter()
+	perf := perf.NewDefaultReporter()
 
 	fn := taskFn(testConfig, perf)
 

--- a/ably/main.go
+++ b/ably/main.go
@@ -7,14 +7,14 @@ import (
 	"github.com/ably/ably-boomer/ably/perf"
 )
 
-func taskFn(testConfig TestConfig) func() {
+func taskFn(testConfig TestConfig, perf *perf.Reporter) func() {
 	switch testConfig.TestType {
 	case "fanout":
-		return curryFanOutTask(testConfig)
+		return curryFanOutTask(testConfig, perf)
 	case "personal":
-		return curryPersonalTask(testConfig)
+		return curryPersonalTask(testConfig, perf)
 	case "sharded":
-		return curryShardedTask(testConfig)
+		return curryShardedTask(testConfig, perf)
 	default:
 		panic("Unknown test type: '" + testConfig.TestType + "'")
 	}
@@ -22,9 +22,9 @@ func taskFn(testConfig TestConfig) func() {
 
 func main() {
 	testConfig := newTestConfig()
-	perf := perf.New()
+	perf := perf.NewReporter()
 
-	fn := taskFn(testConfig)
+	fn := taskFn(testConfig, perf)
 
 	task := &boomer.Task{
 		Name: testConfig.TestType,

--- a/ably/perf/perf.go
+++ b/ably/perf/perf.go
@@ -6,41 +6,45 @@ import (
 	"path"
 	"regexp"
 	"runtime/pprof"
+	"strings"
 	"time"
 
+	"github.com/ably-forks/boomer"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 )
 
-const defaultKeyPrefix = "perf"
+const _defaultKeyPrefix = "perf"
 
 // S3ObjectPutter provides a PutObject function for writing to S3
 type S3ObjectPutter interface {
 	PutObject(*s3.PutObjectInput) (*s3.PutObjectOutput, error)
 }
 
-// Perf provides profiling and performance debugging instrumentation
-type Perf struct {
-	started   bool
-	config    *Config
-	s3Client  S3ObjectPutter
-	pprofFile *os.File
-	fileName  string
+// Reporter provides profiling and performance debugging instrumentation
+type Reporter struct {
+	started       bool
+	config        *Config
+	s3Client      S3ObjectPutter
+	pprofFile     *os.File
+	pprofFileName string
+	hist          *Histogram
+	histFileName  string
 }
 
 // Only allow alphanumeric chars, - _ and . in file names
 var replaceChars = regexp.MustCompile("[^a-zA-Z0-9-_.]")
 
-// New creates a new instance of a Perf with defaults
-func New() *Perf {
-	return &Perf{}
+// NewReporter creates a new instance of a Reporter with defaults
+func NewReporter() *Reporter {
+	return &Reporter{}
 }
 
-// NewWithS3 creates a new instance of a Perf with defaults and a supplied S3
-// client override
-func NewWithS3(config *Config, s3Client S3ObjectPutter) *Perf {
-	return &Perf{
+// NewReporterWithS3 creates a new instance of a Perf with defaults and a
+// supplied S3 client override
+func NewReporterWithS3(config *Config, s3Client S3ObjectPutter) *Reporter {
+	return &Reporter{
 		config:   config,
 		s3Client: s3Client,
 	}
@@ -48,7 +52,7 @@ func NewWithS3(config *Config, s3Client S3ObjectPutter) *Perf {
 
 // Start begins profiling based on the environment configuration. Start should
 // be called at most once. If start is called, stop must be called.
-func (p *Perf) Start() error {
+func (p *Reporter) Start() error {
 	if p.started {
 		return fmt.Errorf("perf is already started")
 	}
@@ -63,24 +67,39 @@ func (p *Perf) Start() error {
 		p.config = perfConfig
 	}
 
-	if p.config.CPUProfileDir == "" {
-		return nil
-	}
-
 	hostname, hostnameErr := os.Hostname()
 	if hostnameErr != nil {
 		hostname = "unknown"
 	}
-	baseName := replaceChars.ReplaceAllString(
+	now := time.Now().Unix()
+
+	if p.config.HistogramDir != "" {
+		p.hist = NewDefaultHistogram()
+		histBaseName := replaceChars.ReplaceAllString(
+			fmt.Sprintf(
+				"latency-%s-%d.hist",
+				hostname,
+				now,
+			),
+			"_",
+		)
+		p.histFileName = path.Join(p.config.HistogramDir, histBaseName)
+	}
+
+	if p.config.CPUProfileDir == "" {
+		return nil
+	}
+
+	pprofBaseName := replaceChars.ReplaceAllString(
 		fmt.Sprintf(
 			"cpuprofile-%s-%d.pprof",
 			hostname,
-			time.Now().Unix(),
+			now,
 		),
 		"_",
 	)
-	p.fileName = path.Join(p.config.CPUProfileDir, baseName)
-	f, fErr := os.Create(p.fileName)
+	p.pprofFileName = path.Join(p.config.CPUProfileDir, pprofBaseName)
+	f, fErr := os.Create(p.pprofFileName)
 	if fErr != nil {
 		return fErr
 	}
@@ -92,14 +111,56 @@ func (p *Perf) Start() error {
 	return nil
 }
 
+// RecordSuccess reports a success.
+func (p *Reporter) RecordSuccess(
+	requestType string,
+	name string,
+	responseTime int64,
+	responseLength int64,
+) {
+	boomer.RecordSuccess(requestType, name, responseTime, responseLength)
+	// TODO: record extra details to logs/histogram
+}
+
+// RecordFailure reports a failure
+func (p *Reporter) RecordFailure(
+	requestType string,
+	name string,
+	responseTime int64,
+	exception string,
+) {
+	boomer.RecordFailure(requestType, name, responseTime, exception)
+	// TODO: record extra details to logs/histogram
+}
+
 // Stop will stop any profiling that was started and write the files to the
 // configured locations (disk and s3). Stop may be called multiple times so
 // it is safe to both call stop directly and defer calls to stop.
-func (p *Perf) Stop() error {
+func (p *Reporter) Stop() error {
 	if !p.started {
 		return nil
 	}
 	p.started = false
+
+	errors := []string(nil)
+
+	pprofErr := p.stopPProf()
+	if pprofErr != nil {
+		errors = append(errors, pprofErr.Error())
+	}
+	histErr := p.stopHist()
+	if histErr != nil {
+		errors = append(errors, histErr.Error())
+	}
+
+	if errors != nil {
+		return fmt.Errorf(strings.Join(errors, ", "))
+	}
+
+	return nil
+}
+
+func (p *Reporter) stopPProf() error {
 	defer p.pprofFile.Close()
 
 	pprof.StopCPUProfile()
@@ -113,15 +174,55 @@ func (p *Perf) Stop() error {
 		return fmt.Errorf("error closing pprof file: %s", closeErr)
 	}
 
-	if p.config.S3Bucket != "" {
-		return p.uploadToS3(p.pprofFile.Name())
+	if p.config.CPUProfileS3Bucket != "" {
+		s3Err := p.uploadToS3(p.pprofFile.Name(), p.config.CPUProfileS3Bucket)
+		if s3Err != nil {
+			return fmt.Errorf("error uploading pprof file to s3: %s", s3Err)
+		}
+	}
+
+	return nil
+}
+
+func (p *Reporter) stopHist() error {
+	if p.hist == nil {
+		return nil
+	}
+
+	histFile, histFileErr := os.Create(p.histFileName)
+	if histFileErr != nil {
+		return fmt.Errorf("error opening histogram file: %s", histFileErr)
+	}
+	defer histFile.Close()
+
+	histWriter := NewHistogramWriter(histFile)
+	writeErr := histWriter.Write(p.hist)
+	if writeErr != nil {
+		return fmt.Errorf("error writing histogram to file: %s", writeErr)
+	}
+
+	syncErr := histFile.Sync()
+	if syncErr != nil {
+		return fmt.Errorf("error syncing histogram file: %s", syncErr)
+	}
+
+	closeErr := histFile.Close()
+	if closeErr != nil {
+		return fmt.Errorf("error closing histogram file: %s", closeErr)
+	}
+
+	if p.config.HistogramS3Bucket != "" {
+		s3Err := p.uploadToS3(histFile.Name(), p.config.HistogramS3Bucket)
+		if s3Err != nil {
+			return fmt.Errorf("error uploading histogram file to s3: %s", s3Err)
+		}
 	}
 
 	return nil
 }
 
 // Returns either the configured s3 client or the default s3 client if unset
-func (p *Perf) configuredS3Client() (S3ObjectPutter, error) {
+func (p *Reporter) configuredS3Client() (S3ObjectPutter, error) {
 	if p.s3Client != nil {
 		return p.s3Client, nil
 	}
@@ -135,7 +236,7 @@ func (p *Perf) configuredS3Client() (S3ObjectPutter, error) {
 }
 
 // Uploads a file to the S3 perf bucket
-func (p *Perf) uploadToS3(fileName string) error {
+func (p *Reporter) uploadToS3(fileName string, bucket string) error {
 	s3Client, s3ClientErr := p.configuredS3Client()
 	if s3ClientErr != nil {
 		return s3ClientErr
@@ -147,7 +248,7 @@ func (p *Perf) uploadToS3(fileName string) error {
 	}
 	defer file.Close()
 
-	key := path.Join(defaultKeyPrefix, path.Base(fileName))
+	key := path.Join(_defaultKeyPrefix, path.Base(fileName))
 
 	// Get file size and read the file content into a buffer
 	fileInfo, fileInfoErr := file.Stat()
@@ -157,7 +258,7 @@ func (p *Perf) uploadToS3(fileName string) error {
 	size := fileInfo.Size()
 
 	_, s3Err := s3Client.PutObject(&s3.PutObjectInput{
-		Bucket:        aws.String(p.config.S3Bucket),
+		Bucket:        aws.String(bucket),
 		Key:           aws.String(key),
 		ACL:           aws.String("private"),
 		Body:          file,

--- a/ably/perf/perf.go
+++ b/ably/perf/perf.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"runtime/pprof"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/ably-forks/boomer"
@@ -15,37 +16,68 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 )
 
-const _defaultKeyPrefix = "perf"
+const _defaultPprofKeyPrefix = "perf"
+const _defaultHistKeyPrefix = "hist"
+
+// Verif that Perf satisfies the LocustReporter interface
+var _ LocustReporter = LocustReporter(&Reporter{})
 
 // S3ObjectPutter provides a PutObject function for writing to S3
 type S3ObjectPutter interface {
 	PutObject(*s3.PutObjectInput) (*s3.PutObjectOutput, error)
 }
 
+// HistMap key indexes histograms by request type and name
+type histMapKey struct {
+	requestType, name, report string
+}
+
+// A latency record contains a histogram entry
+type latencyRecord struct {
+	key          histMapKey
+	responseTime int64
+}
+
+func (h *histMapKey) ID() string {
+	return strings.Join([]string{h.requestType, h.name, h.report}, ".")
+}
+
 // Reporter provides profiling and performance debugging instrumentation
 type Reporter struct {
-	started       bool
+	startTime     int64
+	pprofStarted  bool
+	histStarted   bool
 	config        *Config
+	boomer        LocustReporter
 	s3Client      S3ObjectPutter
 	pprofFile     *os.File
 	pprofFileName string
-	hist          *Histogram
+	hist          map[histMapKey]*Histogram
+	histChan      chan *latencyRecord
+	histChanLock  sync.RWMutex
+	histWG        sync.WaitGroup
+	histMapKey    histMapKey
 	histFileName  string
 }
 
 // Only allow alphanumeric chars, - _ and . in file names
 var replaceChars = regexp.MustCompile("[^a-zA-Z0-9-_.]")
 
-// NewReporter creates a new instance of a Reporter with defaults
-func NewReporter() *Reporter {
+// NewDefaultReporter creates a new instance of a Reporter with defaults
+func NewDefaultReporter() *Reporter {
 	return &Reporter{}
 }
 
-// NewReporterWithS3 creates a new instance of a Perf with defaults and a
-// supplied S3 client override
-func NewReporterWithS3(config *Config, s3Client S3ObjectPutter) *Reporter {
+// NewReporter creates a new instance of a Perf with the supplied config and
+// clients
+func NewReporter(
+	config *Config,
+	boomer LocustReporter,
+	s3Client S3ObjectPutter,
+) *Reporter {
 	return &Reporter{
 		config:   config,
+		boomer:   boomer,
 		s3Client: s3Client,
 	}
 }
@@ -53,8 +85,28 @@ func NewReporterWithS3(config *Config, s3Client S3ObjectPutter) *Reporter {
 // Start begins profiling based on the environment configuration. Start should
 // be called at most once. If start is called, stop must be called.
 func (p *Reporter) Start() error {
-	if p.started {
-		return fmt.Errorf("perf is already started")
+	errors := []string(nil)
+	p.startTime = time.Now().Unix()
+
+	pprofErr := p.startPProf()
+	if pprofErr != nil {
+		errors = append(errors, pprofErr.Error())
+	}
+	histErr := p.startHist()
+	if histErr != nil {
+		errors = append(errors, histErr.Error())
+	}
+
+	if errors != nil {
+		return fmt.Errorf(strings.Join(errors, ", "))
+	}
+
+	return nil
+}
+
+func (p *Reporter) startPProf() error {
+	if p.pprofStarted {
+		return fmt.Errorf("pprof is already started")
 	}
 
 	if p.config == nil {
@@ -71,20 +123,7 @@ func (p *Reporter) Start() error {
 	if hostnameErr != nil {
 		hostname = "unknown"
 	}
-	now := time.Now().Unix()
-
-	if p.config.HistogramDir != "" {
-		p.hist = NewDefaultHistogram()
-		histBaseName := replaceChars.ReplaceAllString(
-			fmt.Sprintf(
-				"latency-%s-%d.hist",
-				hostname,
-				now,
-			),
-			"_",
-		)
-		p.histFileName = path.Join(p.config.HistogramDir, histBaseName)
-	}
+	now := p.startTime
 
 	if p.config.CPUProfileDir == "" {
 		return nil
@@ -105,8 +144,49 @@ func (p *Reporter) Start() error {
 	}
 
 	p.pprofFile = f
-	p.started = true
+	p.pprofStarted = true
 	pprof.StartCPUProfile(f)
+
+	return nil
+}
+
+func (p *Reporter) startHist() error {
+	if p.histStarted {
+		return fmt.Errorf("histogram is already started")
+	}
+
+	if p.config == nil {
+		perfConfig, perfConfigErr := NewConfig(os.LookupEnv)
+
+		if perfConfigErr != nil {
+			return perfConfigErr
+		}
+
+		p.config = perfConfig
+	}
+
+	hostname, hostnameErr := os.Hostname()
+	if hostnameErr != nil {
+		hostname = "unknown"
+	}
+	now := p.startTime
+
+	if p.config.HistogramDir != "" {
+		p.hist = map[histMapKey]*Histogram{}
+		histBaseName := replaceChars.ReplaceAllString(
+			fmt.Sprintf(
+				"latency-%s-%d.hist",
+				hostname,
+				now,
+			),
+			"_",
+		)
+		p.histFileName = path.Join(p.config.HistogramDir, histBaseName)
+		p.histChan = make(chan *latencyRecord)
+		p.histWG.Add(1)
+		go p.recordLatencies()
+		p.histStarted = true
+	}
 
 	return nil
 }
@@ -119,7 +199,14 @@ func (p *Reporter) RecordSuccess(
 	responseLength int64,
 ) {
 	boomer.RecordSuccess(requestType, name, responseTime, responseLength)
-	// TODO: record extra details to logs/histogram
+	p.histChanLock.RLock()
+	defer p.histChanLock.RUnlock()
+	if p.histStarted {
+		p.histChan <- &latencyRecord{
+			key:          histMapKey{requestType, name, "success"},
+			responseTime: responseTime,
+		}
+	}
 }
 
 // RecordFailure reports a failure
@@ -130,18 +217,20 @@ func (p *Reporter) RecordFailure(
 	exception string,
 ) {
 	boomer.RecordFailure(requestType, name, responseTime, exception)
-	// TODO: record extra details to logs/histogram
+	p.histChanLock.RLock()
+	defer p.histChanLock.RUnlock()
+	if p.histStarted {
+		p.histChan <- &latencyRecord{
+			key:          histMapKey{requestType, name, "failure"},
+			responseTime: responseTime,
+		}
+	}
 }
 
 // Stop will stop any profiling that was started and write the files to the
 // configured locations (disk and s3). Stop may be called multiple times so
 // it is safe to both call stop directly and defer calls to stop.
 func (p *Reporter) Stop() error {
-	if !p.started {
-		return nil
-	}
-	p.started = false
-
 	errors := []string(nil)
 
 	pprofErr := p.stopPProf()
@@ -161,7 +250,11 @@ func (p *Reporter) Stop() error {
 }
 
 func (p *Reporter) stopPProf() error {
+	if !p.pprofStarted {
+		return nil
+	}
 	defer p.pprofFile.Close()
+	p.pprofStarted = false
 
 	pprof.StopCPUProfile()
 	syncErr := p.pprofFile.Sync()
@@ -175,7 +268,11 @@ func (p *Reporter) stopPProf() error {
 	}
 
 	if p.config.CPUProfileS3Bucket != "" {
-		s3Err := p.uploadToS3(p.pprofFile.Name(), p.config.CPUProfileS3Bucket)
+		s3Err := p.uploadToS3(
+			_defaultPprofKeyPrefix,
+			p.pprofFile.Name(),
+			p.config.CPUProfileS3Bucket,
+		)
 		if s3Err != nil {
 			return fmt.Errorf("error uploading pprof file to s3: %s", s3Err)
 		}
@@ -185,9 +282,15 @@ func (p *Reporter) stopPProf() error {
 }
 
 func (p *Reporter) stopHist() error {
-	if p.hist == nil {
+	if !p.histStarted {
 		return nil
 	}
+
+	p.histChanLock.Lock()
+	p.histStarted = false
+	close(p.histChan)
+	p.histChanLock.Unlock()
+	p.histWG.Wait()
 
 	histFile, histFileErr := os.Create(p.histFileName)
 	if histFileErr != nil {
@@ -195,10 +298,13 @@ func (p *Reporter) stopHist() error {
 	}
 	defer histFile.Close()
 
+	// Write all of the histograms to the gob stream
 	histWriter := NewHistogramWriter(histFile)
-	writeErr := histWriter.Write(p.hist)
-	if writeErr != nil {
-		return fmt.Errorf("error writing histogram to file: %s", writeErr)
+	for key, hist := range p.hist {
+		writeErr := histWriter.Write(key.ID(), hist)
+		if writeErr != nil {
+			return fmt.Errorf("error writing histogram to file: %s", writeErr)
+		}
 	}
 
 	syncErr := histFile.Sync()
@@ -212,7 +318,11 @@ func (p *Reporter) stopHist() error {
 	}
 
 	if p.config.HistogramS3Bucket != "" {
-		s3Err := p.uploadToS3(histFile.Name(), p.config.HistogramS3Bucket)
+		s3Err := p.uploadToS3(
+			_defaultHistKeyPrefix,
+			histFile.Name(),
+			p.config.HistogramS3Bucket,
+		)
 		if s3Err != nil {
 			return fmt.Errorf("error uploading histogram file to s3: %s", s3Err)
 		}
@@ -231,12 +341,17 @@ func (p *Reporter) configuredS3Client() (S3ObjectPutter, error) {
 	if sessErr != nil {
 		return nil, sessErr
 	}
+	p.s3Client = s3.New(sess)
 
-	return s3.New(sess), nil
+	return p.s3Client, nil
 }
 
 // Uploads a file to the S3 perf bucket
-func (p *Reporter) uploadToS3(fileName string, bucket string) error {
+func (p *Reporter) uploadToS3(
+	prefix string,
+	fileName string,
+	bucket string,
+) error {
 	s3Client, s3ClientErr := p.configuredS3Client()
 	if s3ClientErr != nil {
 		return s3ClientErr
@@ -248,7 +363,16 @@ func (p *Reporter) uploadToS3(fileName string, bucket string) error {
 	}
 	defer file.Close()
 
-	key := path.Join(_defaultKeyPrefix, path.Base(fileName))
+	var key string
+	if prefix == "" {
+		key = path.Base(fileName)
+	} else {
+		safePrefix := replaceChars.ReplaceAllString(prefix, "_")
+		key = path.Join(
+			safePrefix,
+			path.Base(fileName),
+		)
+	}
 
 	// Get file size and read the file content into a buffer
 	fileInfo, fileInfoErr := file.Stat()
@@ -271,4 +395,22 @@ func (p *Reporter) uploadToS3(fileName string, bucket string) error {
 	}
 
 	return nil
+}
+
+// recordLatencies inserts latency records into the correct histogram. This in
+// executed inside a single goroutine to prevent race conditions on the
+// histogram structures.
+func (p *Reporter) recordLatencies() {
+	for record := range p.histChan {
+		histogram, ok := p.hist[record.key]
+
+		if !ok {
+			histogram = NewDefaultHistogram()
+			p.hist[record.key] = histogram
+		}
+
+		histogram.Add(record.responseTime)
+	}
+
+	p.histWG.Done()
 }

--- a/ably/perf/perf.go
+++ b/ably/perf/perf.go
@@ -384,7 +384,7 @@ func (p *Reporter) uploadToS3(
 	_, s3Err := s3Client.PutObject(&s3.PutObjectInput{
 		Bucket:        aws.String(bucket),
 		Key:           aws.String(key),
-		ACL:           aws.String("private"),
+		ACL:           aws.String("authenticated-read"),
 		Body:          file,
 		ContentLength: aws.Int64(size),
 		ContentType:   aws.String("application/octet-stream"),

--- a/ably/perf/perf.go
+++ b/ably/perf/perf.go
@@ -382,9 +382,9 @@ func (p *Reporter) uploadToS3(
 	size := fileInfo.Size()
 
 	_, s3Err := s3Client.PutObject(&s3.PutObjectInput{
-		Bucket:        aws.String(bucket),
-		Key:           aws.String(key),
-		ACL:           aws.String("authenticated-read"),
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+		// ACL:           aws.String("authenticated-read"),
 		Body:          file,
 		ContentLength: aws.Int64(size),
 		ContentType:   aws.String("application/octet-stream"),

--- a/ably/perf/perf_config.go
+++ b/ably/perf/perf_config.go
@@ -1,13 +1,17 @@
 package perf
 
-const defaultCPUProfileDir = ""
-const defaultS3Bucket = ""
+const _defaultCPUProfileDir = ""
+const _defaultCPUProfileS3Bucket = ""
+const _defaultHistogramDir = ""
+const _defaultHistogramS3Bucket = ""
 
 // Config configures the internal profilers for measuring performance and
 // latency information directly from the client
 type Config struct {
-	CPUProfileDir string
-	S3Bucket      string
+	CPUProfileDir      string
+	CPUProfileS3Bucket string
+	HistogramDir       string
+	HistogramS3Bucket  string
 }
 
 // LookupEnvFunc is an environment lookup function to determin envionment
@@ -17,8 +21,10 @@ type LookupEnvFunc func(key string) (string, bool)
 // NewConfig initializes a perf Config from the supplied environment
 func NewConfig(lookupEnv LookupEnvFunc) (*Config, error) {
 	config := &Config{
-		CPUProfileDir: defaultCPUProfileDir,
-		S3Bucket:      defaultS3Bucket,
+		CPUProfileDir:      _defaultCPUProfileDir,
+		CPUProfileS3Bucket: _defaultCPUProfileS3Bucket,
+		HistogramDir:       _defaultHistogramDir,
+		HistogramS3Bucket:  _defaultHistogramS3Bucket,
 	}
 
 	cpuProfile, cpuProfileExists := lookupEnv("PERF_CPU_PROFILE_DIR")
@@ -26,9 +32,19 @@ func NewConfig(lookupEnv LookupEnvFunc) (*Config, error) {
 		config.CPUProfileDir = cpuProfile
 	}
 
-	s3Bucket, s3BucketExists := lookupEnv("PERF_CPU_S3_BUCKET")
-	if s3BucketExists {
-		config.S3Bucket = s3Bucket
+	cpuProfileS3, cpuProfileS3Exists := lookupEnv("PERF_CPU_S3_BUCKET")
+	if cpuProfileS3Exists {
+		config.CPUProfileS3Bucket = cpuProfileS3
+	}
+
+	histogram, histogramExists := lookupEnv("PERF_HISTOGRAM_DIR")
+	if histogramExists {
+		config.HistogramDir = histogram
+	}
+
+	histogramS3, histogramS3Exists := lookupEnv("PERF_HISTOGRAM_S3_BUCKET")
+	if histogramS3Exists {
+		config.HistogramS3Bucket = histogramS3
 	}
 
 	return config, nil

--- a/ably/perf/perf_config.go
+++ b/ably/perf/perf_config.go
@@ -32,7 +32,7 @@ func NewConfig(lookupEnv LookupEnvFunc) (*Config, error) {
 		config.CPUProfileDir = cpuProfile
 	}
 
-	cpuProfileS3, cpuProfileS3Exists := lookupEnv("PERF_CPU_S3_BUCKET")
+	cpuProfileS3, cpuProfileS3Exists := lookupEnv("PERF_CPU_PROFILE_S3_BUCKET")
 	if cpuProfileS3Exists {
 		config.CPUProfileS3Bucket = cpuProfileS3
 	}

--- a/ably/perf/perf_config_test.go
+++ b/ably/perf/perf_config_test.go
@@ -56,10 +56,10 @@ func TestNewPerfConfig(t *testing.T) {
 
 	t.Run("all perf environment variables set", func(ts *testing.T) {
 		var testEnv testEnvMap = map[string]string{
-			"PERF_CPU_PROFILE_DIR":     "/tmp",
-			"PERF_CPU_S3_BUCKET":       "ably-logs-dev",
-			"PERF_HISTOGRAM_DIR":       "/tmp/histogram",
-			"PERF_HISTOGRAM_S3_BUCKET": "ably-hist-dev",
+			"PERF_CPU_PROFILE_DIR":       "/tmp",
+			"PERF_CPU_PROFILE_S3_BUCKET": "ably-logs-dev",
+			"PERF_HISTOGRAM_DIR":         "/tmp/histogram",
+			"PERF_HISTOGRAM_S3_BUCKET":   "ably-hist-dev",
 		}
 
 		config, err := NewConfig(testEnv.LookupEnv)
@@ -75,11 +75,11 @@ func TestNewPerfConfig(t *testing.T) {
 			)
 		}
 
-		if config.CPUProfileS3Bucket != testEnv["PERF_CPU_S3_BUCKET"] {
+		if config.CPUProfileS3Bucket != testEnv["PERF_CPU_PROFILE_S3_BUCKET"] {
 			t.Errorf(
 				"CPUProfileS3Bucket was incorrect, got: %s, wanted: %s",
 				config.CPUProfileS3Bucket,
-				testEnv["PERF_CPU_S3_BUCKET"],
+				testEnv["PERF_CPU_PROFILE_S3_BUCKET"],
 			)
 		}
 

--- a/ably/perf/perf_config_test.go
+++ b/ably/perf/perf_config_test.go
@@ -21,27 +21,45 @@ func TestNewPerfConfig(t *testing.T) {
 			t.Fatalf("failed to initialize perf config: %s", err)
 		}
 
-		if config.CPUProfileDir != defaultCPUProfileDir {
+		if config.CPUProfileDir != _defaultCPUProfileDir {
 			t.Errorf(
 				"CPUProfileDir was incorrect, got: %s, wanted: %s",
 				config.CPUProfileDir,
-				defaultCPUProfileDir,
+				_defaultCPUProfileDir,
 			)
 		}
 
-		if config.S3Bucket != defaultS3Bucket {
+		if config.CPUProfileS3Bucket != _defaultCPUProfileS3Bucket {
 			t.Errorf(
-				"S3Bucket was incorrect, got: %s, wanted: %s",
-				config.S3Bucket,
-				defaultS3Bucket,
+				"CPUProfileS3Bucket was incorrect, got: %s, wanted: %s",
+				config.CPUProfileS3Bucket,
+				_defaultCPUProfileS3Bucket,
+			)
+		}
+
+		if config.HistogramDir != _defaultHistogramDir {
+			t.Errorf(
+				"HistogramDir was incorrect, got: %s, wanted: %s",
+				config.HistogramDir,
+				_defaultHistogramDir,
+			)
+		}
+
+		if config.HistogramS3Bucket != _defaultHistogramS3Bucket {
+			t.Errorf(
+				"HistogramS3Bucket was incorrect, got: %s, wanted: %s",
+				config.HistogramS3Bucket,
+				_defaultHistogramS3Bucket,
 			)
 		}
 	})
 
 	t.Run("all perf environment variables set", func(ts *testing.T) {
 		var testEnv testEnvMap = map[string]string{
-			"PERF_CPU_PROFILE_DIR": "/tmp",
-			"PERF_CPU_S3_BUCKET":   "ably-logs-dev",
+			"PERF_CPU_PROFILE_DIR":     "/tmp",
+			"PERF_CPU_S3_BUCKET":       "ably-logs-dev",
+			"PERF_HISTOGRAM_DIR":       "/tmp/histogram",
+			"PERF_HISTOGRAM_S3_BUCKET": "ably-hist-dev",
 		}
 
 		config, err := NewConfig(testEnv.LookupEnv)
@@ -53,17 +71,32 @@ func TestNewPerfConfig(t *testing.T) {
 			t.Errorf(
 				"CPUProfileDir was incorrect, got: %s, wanted: %s",
 				config.CPUProfileDir,
-				defaultCPUProfileDir,
+				testEnv["PERF_CPU_PROFILE_DIR"],
 			)
 		}
 
-		if config.S3Bucket != testEnv["PERF_CPU_S3_BUCKET"] {
+		if config.CPUProfileS3Bucket != testEnv["PERF_CPU_S3_BUCKET"] {
 			t.Errorf(
-				"S3Bucket was incorrect, got: %s, wanted: %s",
-				config.S3Bucket,
-				defaultS3Bucket,
+				"CPUProfileS3Bucket was incorrect, got: %s, wanted: %s",
+				config.CPUProfileS3Bucket,
+				testEnv["PERF_CPU_S3_BUCKET"],
 			)
 		}
 
+		if config.HistogramDir != testEnv["PERF_HISTOGRAM_DIR"] {
+			t.Errorf(
+				"HistogramS3Dir was incorrect, got: %s, wanted: %s",
+				config.HistogramDir,
+				testEnv["PERF_HISTOGRAM_DIR"],
+			)
+		}
+
+		if config.HistogramS3Bucket != testEnv["PERF_HISTOGRAM_S3_BUCKET"] {
+			t.Errorf(
+				"HistogramS3Bucket was incorrect, got: %s, wanted: %s",
+				config.HistogramDir,
+				testEnv["PERF_HISTOGRAM_S3_BUCKET"],
+			)
+		}
 	})
 }

--- a/ably/perf/perf_histogram.go
+++ b/ably/perf/perf_histogram.go
@@ -79,7 +79,10 @@ func NewDefaultHistogram() *Histogram {
 // of buckets, starting from the provided min value and spread with the
 // specified bucket width
 func NewHistogram(bucketCount int, minValue int64, bucketWidth int64) *Histogram {
-	bucketWidth = absInt64(bucketWidth)
+	if bucketWidth < 0 {
+		bucketWidth = -1 * bucketWidth
+		minValue = minValue - (bucketWidth * int64(bucketCount)) + 1
+	}
 
 	histogram := &Histogram{
 		bucketCount: bucketCount,
@@ -256,11 +259,4 @@ func (h *Histogram) maxPossibleValue() int64 {
 // of 4 samples is 2 samples (where the percentile line runs between 2 and 3).
 func percentileToSamples(totalSamples, numerator, denominator int64) int64 {
 	return 1 + (((totalSamples * numerator) - 1) / denominator)
-}
-
-func absInt64(i int64) int64 {
-	if i < 0 {
-		return -1 * i
-	}
-	return i
 }

--- a/ably/perf/perf_histogram.go
+++ b/ably/perf/perf_histogram.go
@@ -45,30 +45,31 @@ type Histogram struct {
 // value is 17, all percentile values will be capped to 17 as this is a better
 // upper limit than the bucket max value of 20.
 type Percentiles struct {
-	Min     int64
-	Pct5    int64
-	Pct10   int64
-	Pct15   int64
-	Pct20   int64
-	Pct25   int64
-	Pct30   int64
-	Pct35   int64
-	Pct40   int64
-	Pct45   int64
-	Pct50   int64
-	Pct55   int64
-	Pct60   int64
-	Pct65   int64
-	Pct70   int64
-	Pct75   int64
-	Pct80   int64
-	Pct85   int64
-	Pct90   int64
-	Pct95   int64
-	Pct99   int64
-	Pct999  int64
-	Pct9999 int64
-	Max     int64
+	Min          int64
+	Pct5         int64
+	Pct10        int64
+	Pct15        int64
+	Pct20        int64
+	Pct25        int64
+	Pct30        int64
+	Pct35        int64
+	Pct40        int64
+	Pct45        int64
+	Pct50        int64
+	Pct55        int64
+	Pct60        int64
+	Pct65        int64
+	Pct70        int64
+	Pct75        int64
+	Pct80        int64
+	Pct85        int64
+	Pct90        int64
+	Pct95        int64
+	Pct99        int64
+	Pct999       int64
+	Pct9999      int64
+	Max          int64
+	TotalSamples int64
 }
 
 // NewDefaultHistogram returns  a histogram of 1ms to 60000ms, spaced 1ms apart
@@ -191,30 +192,31 @@ func (h *Histogram) Percentiles() *Percentiles {
 	}
 
 	return &Percentiles{
-		Min:     h.sampleMin,
-		Pct5:    h.bucketToMaxValue(btos[0]),
-		Pct10:   h.bucketToMaxValue(btos[1]),
-		Pct15:   h.bucketToMaxValue(btos[2]),
-		Pct20:   h.bucketToMaxValue(btos[3]),
-		Pct25:   h.bucketToMaxValue(btos[4]),
-		Pct30:   h.bucketToMaxValue(btos[5]),
-		Pct35:   h.bucketToMaxValue(btos[6]),
-		Pct40:   h.bucketToMaxValue(btos[7]),
-		Pct45:   h.bucketToMaxValue(btos[8]),
-		Pct50:   h.bucketToMaxValue(btos[9]),
-		Pct55:   h.bucketToMaxValue(btos[10]),
-		Pct60:   h.bucketToMaxValue(btos[11]),
-		Pct65:   h.bucketToMaxValue(btos[12]),
-		Pct70:   h.bucketToMaxValue(btos[13]),
-		Pct75:   h.bucketToMaxValue(btos[14]),
-		Pct80:   h.bucketToMaxValue(btos[15]),
-		Pct85:   h.bucketToMaxValue(btos[16]),
-		Pct90:   h.bucketToMaxValue(btos[17]),
-		Pct95:   h.bucketToMaxValue(btos[18]),
-		Pct99:   h.bucketToMaxValue(btos[19]),
-		Pct999:  h.bucketToMaxValue(btos[20]),
-		Pct9999: h.bucketToMaxValue(btos[21]),
-		Max:     h.sampleMax,
+		Min:          h.sampleMin,
+		Pct5:         h.bucketToMaxValue(btos[0]),
+		Pct10:        h.bucketToMaxValue(btos[1]),
+		Pct15:        h.bucketToMaxValue(btos[2]),
+		Pct20:        h.bucketToMaxValue(btos[3]),
+		Pct25:        h.bucketToMaxValue(btos[4]),
+		Pct30:        h.bucketToMaxValue(btos[5]),
+		Pct35:        h.bucketToMaxValue(btos[6]),
+		Pct40:        h.bucketToMaxValue(btos[7]),
+		Pct45:        h.bucketToMaxValue(btos[8]),
+		Pct50:        h.bucketToMaxValue(btos[9]),
+		Pct55:        h.bucketToMaxValue(btos[10]),
+		Pct60:        h.bucketToMaxValue(btos[11]),
+		Pct65:        h.bucketToMaxValue(btos[12]),
+		Pct70:        h.bucketToMaxValue(btos[13]),
+		Pct75:        h.bucketToMaxValue(btos[14]),
+		Pct80:        h.bucketToMaxValue(btos[15]),
+		Pct85:        h.bucketToMaxValue(btos[16]),
+		Pct90:        h.bucketToMaxValue(btos[17]),
+		Pct95:        h.bucketToMaxValue(btos[18]),
+		Pct99:        h.bucketToMaxValue(btos[19]),
+		Pct999:       h.bucketToMaxValue(btos[20]),
+		Pct9999:      h.bucketToMaxValue(btos[21]),
+		Max:          h.sampleMax,
+		TotalSamples: h.totalSamples,
 	}
 }
 

--- a/ably/perf/perf_histogram.go
+++ b/ably/perf/perf_histogram.go
@@ -1,0 +1,266 @@
+package perf
+
+// Default histogram to [1,60000] milliseconds with 1ms buckets
+const _defaultMinTime = 1
+const _defaultBucketCount = 60000
+const _defaultBucketWidth = 1
+
+// Histogram provides a linearly spaced histogram of int64 samples, with
+// configurable minimum value and bucket width.
+type Histogram struct {
+	bucketCount     int
+	buckets         []int64
+	min             int64
+	max             int64
+	bucketWidth     int64
+	sampleMin       int64
+	sampleMax       int64
+	lowSampleCount  int64
+	highSampleCount int64
+	totalSamples    int64
+}
+
+// Percentiles contains the different percentiles that repreent the makeup of
+// a histogram. The value is not interpolated, but the value of the bucket
+// assocatied with the sample that overlaps the percentile line. For example
+// if there are 3 samples, the p50 will be the value will be the bucket that
+// contains the second sample. If there are 4 samples, the p50 will be the
+// value of the bucket that contains the 2nd sample.
+//
+// Bucket values are reported to be the maximum possible value for that bucket.
+// So for example, if we have 4 buckets with a min of 1 and a width of 5,
+// the value of bucket 0 will be 5, as samples in bucket 0 can be 1,2,3,4,5.
+// This allows us to report that every sample at a given percentile is less
+// than or equal to the reported value. If we were to take a bucket midpoint,
+// some samples within the percentile could be higher than what is reporterd.
+//
+// The values are also clamped at the sample max value, so if the histogram is
+// formed from 4 buckes with min 1 and width of 5, and the maximum sample
+// value is 17, all percentile values will be capped to 17 as this is a better
+// upper limit than the bucket max value of 20.
+type Percentiles struct {
+	Min     int64
+	Pct5    int64
+	Pct10   int64
+	Pct15   int64
+	Pct20   int64
+	Pct25   int64
+	Pct30   int64
+	Pct35   int64
+	Pct40   int64
+	Pct45   int64
+	Pct50   int64
+	Pct55   int64
+	Pct60   int64
+	Pct65   int64
+	Pct70   int64
+	Pct75   int64
+	Pct80   int64
+	Pct85   int64
+	Pct90   int64
+	Pct95   int64
+	Pct99   int64
+	Pct999  int64
+	Pct9999 int64
+	Max     int64
+}
+
+// NewDefaultHistogram returns  a histogram of 1ms to 60000ms, spaced 1ms apart
+// (record every ms up 60s)
+func NewDefaultHistogram() *Histogram {
+	return NewHistogram(
+		_defaultBucketCount,
+		_defaultMinTime,
+		_defaultBucketWidth,
+	)
+}
+
+// NewHistogram returns a linearly spaced histogram with the given number
+// of buckets, starting from the provided min value and spread with the
+// specified bucket width
+func NewHistogram(bucketCount int, minValue int64, bucketWidth int64) *Histogram {
+	bucketWidth = absInt64(bucketWidth)
+
+	histogram := &Histogram{
+		bucketCount: bucketCount,
+		buckets:     make([]int64, bucketCount),
+		min:         minValue,
+		bucketWidth: bucketWidth,
+	}
+
+	histogram.max = histogram.maxPossibleValue()
+
+	return histogram
+}
+
+// Add appends a sample to the histogram. Values that our out of range are
+// tallied in the low/high sample count fields
+func (h *Histogram) Add(value int64) {
+	if h.totalSamples == 0 {
+		h.sampleMin = value
+		h.sampleMax = value
+	} else {
+		if value < h.sampleMin {
+			h.sampleMin = value
+		}
+		if value > h.sampleMax {
+			h.sampleMax = value
+		}
+	}
+	h.totalSamples++
+
+	bucket := h.sampleToBucket(value)
+
+	if bucket < 0 {
+		h.lowSampleCount++
+	} else if bucket >= h.bucketCount {
+		h.highSampleCount++
+	} else {
+		h.buckets[bucket]++
+	}
+}
+
+// Percentiles returns the histogram percentiles. The statistic means that
+// x% of samples were this value or less. When x% refers to a fractional number
+// of samples, the ceil(x%) is used. This ensures that the provded values are
+// always an upper bound for the given percentile. For example, the p50 of a
+// 11 samples is at 5.5 samples. The returned p50 will be the max possible
+// value of the bucket that sample 6 lies in. This is then clamped by the
+// absolute sample maximum, as the max possible sample can exceed the max
+// observed sample.
+func (h *Histogram) Percentiles() *Percentiles {
+	totalSamples := h.totalSamples
+	buckets := h.buckets
+	bucketCount := h.bucketCount
+
+	if totalSamples <= 0 {
+		return &Percentiles{}
+	}
+
+	stob := []int64{
+		percentileToSamples(totalSamples, 5, 100),
+		percentileToSamples(totalSamples, 10, 100),
+		percentileToSamples(totalSamples, 15, 100),
+		percentileToSamples(totalSamples, 20, 100),
+		percentileToSamples(totalSamples, 25, 100),
+		percentileToSamples(totalSamples, 30, 100),
+		percentileToSamples(totalSamples, 35, 100),
+		percentileToSamples(totalSamples, 40, 100),
+		percentileToSamples(totalSamples, 45, 100),
+		percentileToSamples(totalSamples, 50, 100),
+		percentileToSamples(totalSamples, 55, 100),
+		percentileToSamples(totalSamples, 60, 100),
+		percentileToSamples(totalSamples, 65, 100),
+		percentileToSamples(totalSamples, 70, 100),
+		percentileToSamples(totalSamples, 75, 100),
+		percentileToSamples(totalSamples, 80, 100),
+		percentileToSamples(totalSamples, 85, 100),
+		percentileToSamples(totalSamples, 90, 100),
+		percentileToSamples(totalSamples, 95, 100),
+		percentileToSamples(totalSamples, 99, 100),
+		percentileToSamples(totalSamples, 999, 1000),
+		percentileToSamples(totalSamples, 9999, 10000),
+	}
+
+	btos := make([]int, len(stob))
+
+	var sampleCount int64
+	find := 0
+	for i := -1; i <= bucketCount; i++ {
+		if i < 0 {
+			sampleCount += h.lowSampleCount
+		} else if i >= bucketCount {
+			sampleCount += h.highSampleCount
+		} else {
+			sampleCount += buckets[i]
+		}
+
+		// Determines if this bucket representes one of the percentiles
+		for ; find < len(stob) && stob[find] <= sampleCount; find++ {
+			btos[find] = i
+		}
+	}
+
+	return &Percentiles{
+		Min:     h.sampleMin,
+		Pct5:    h.bucketToMaxValue(btos[0]),
+		Pct10:   h.bucketToMaxValue(btos[1]),
+		Pct15:   h.bucketToMaxValue(btos[2]),
+		Pct20:   h.bucketToMaxValue(btos[3]),
+		Pct25:   h.bucketToMaxValue(btos[4]),
+		Pct30:   h.bucketToMaxValue(btos[5]),
+		Pct35:   h.bucketToMaxValue(btos[6]),
+		Pct40:   h.bucketToMaxValue(btos[7]),
+		Pct45:   h.bucketToMaxValue(btos[8]),
+		Pct50:   h.bucketToMaxValue(btos[9]),
+		Pct55:   h.bucketToMaxValue(btos[10]),
+		Pct60:   h.bucketToMaxValue(btos[11]),
+		Pct65:   h.bucketToMaxValue(btos[12]),
+		Pct70:   h.bucketToMaxValue(btos[13]),
+		Pct75:   h.bucketToMaxValue(btos[14]),
+		Pct80:   h.bucketToMaxValue(btos[15]),
+		Pct85:   h.bucketToMaxValue(btos[16]),
+		Pct90:   h.bucketToMaxValue(btos[17]),
+		Pct95:   h.bucketToMaxValue(btos[18]),
+		Pct99:   h.bucketToMaxValue(btos[19]),
+		Pct999:  h.bucketToMaxValue(btos[20]),
+		Pct9999: h.bucketToMaxValue(btos[21]),
+		Max:     h.sampleMax,
+	}
+}
+
+// Given a sample, return which bucket it belongs to.
+func (h *Histogram) sampleToBucket(sample int64) int {
+	if sample > h.max {
+		return h.bucketCount
+	}
+
+	if sample < h.min {
+		return -1
+	}
+
+	return int((sample - h.min) / h.bucketWidth)
+}
+
+// Given a bucket index, compute the maximum value of the bucket and clamp to
+// the max sample value
+func (h *Histogram) bucketToMaxValue(bucketIndex int) int64 {
+	if bucketIndex < 0 {
+		possibleMin := h.min - 1
+		if possibleMin > h.sampleMax {
+			return h.sampleMax
+		}
+		return possibleMin
+	}
+
+	if bucketIndex >= h.bucketCount {
+		return h.sampleMax
+	}
+
+	bucketMax := h.min + ((1 + int64(bucketIndex)) * h.bucketWidth) - 1
+
+	if h.sampleMax < bucketMax {
+		return h.sampleMax
+	}
+
+	return bucketMax
+}
+
+// Compute the largest possible value in the last bucket
+func (h *Histogram) maxPossibleValue() int64 {
+	return h.min + ((int64(h.bucketCount)) * h.bucketWidth) - 1
+}
+
+// Given a percentile (numerator/denominator), return which sample number
+// overlaps the percentile. At overlapping boundaries, round down, i.e. 50%
+// of 4 samples is 2 samples (where the percentile line runs between 2 and 3).
+func percentileToSamples(totalSamples, numerator, denominator int64) int64 {
+	return 1 + (((totalSamples * numerator) - 1) / denominator)
+}
+
+func absInt64(i int64) int64 {
+	if i < 0 {
+		return -1 * i
+	}
+	return i
+}

--- a/ably/perf/perf_histogram_test.go
+++ b/ably/perf/perf_histogram_test.go
@@ -45,6 +45,7 @@ func TestNewHistogram(t *testing.T) {
 			59941,
 			59995,
 			60001,
+			60002,
 		})
 
 		percentiles := hist.Percentiles()
@@ -85,6 +86,7 @@ func TestNewHistogram(t *testing.T) {
 			59945,
 			59995,
 			60001,
+			60002,
 		})
 
 		percentiles := hist.Percentiles()
@@ -124,7 +126,7 @@ func TestNewHistogram(t *testing.T) {
 			0,
 			0,
 			0,
-			0,
+			60002,
 		})
 
 		percentiles := hist.Percentiles()
@@ -164,7 +166,7 @@ func TestNewHistogram(t *testing.T) {
 			120002,
 			120002,
 			120002,
-			120002,
+			60002,
 		})
 
 		percentiles := hist.Percentiles()
@@ -216,6 +218,7 @@ func TestNewHistogram(t *testing.T) {
 			59945,
 			59994,
 			59994,
+			60002,
 		})
 
 		percentiles := hist.Percentiles()
@@ -255,6 +258,7 @@ func TestNewHistogram(t *testing.T) {
 			-6,
 			-6,
 			-6,
+			2,
 		})
 
 		percentiles := hist.Percentiles()
@@ -294,6 +298,7 @@ func TestNewHistogram(t *testing.T) {
 			-60,
 			-6,
 			0,
+			60002,
 		})
 
 		percentiles := hist.Percentiles()
@@ -333,6 +338,7 @@ func TestNewHistogram(t *testing.T) {
 			59945,
 			59995,
 			60001,
+			60002,
 		})
 
 		percentiles := hist.Percentiles()
@@ -383,6 +389,7 @@ func TestNewHistogramSimulation(t *testing.T) {
 			sampleLog[percentileToSamples(samples, 999, 1000)],
 			sampleLog[percentileToSamples(samples, 9999, 10000)],
 			sampleLog[samples-1],
+			int64(len(sampleLog)),
 		})
 
 		percentiles := hist.Percentiles()
@@ -854,34 +861,44 @@ func assertEqualPercentiles(
 			actual.Max,
 		)
 	}
+
+	if actual.TotalSamples != expected.TotalSamples {
+		t.Errorf(
+			"unepxected percentile TotalSamples value, wanted: %d, got %d",
+			expected.TotalSamples,
+			actual.TotalSamples,
+		)
+	}
+
 }
 
 func percentilesFromArray(arr []int64) *Percentiles {
 	return &Percentiles{
-		Min:     arr[0],
-		Pct5:    arr[1],
-		Pct10:   arr[2],
-		Pct15:   arr[3],
-		Pct20:   arr[4],
-		Pct25:   arr[5],
-		Pct30:   arr[6],
-		Pct35:   arr[7],
-		Pct40:   arr[8],
-		Pct45:   arr[9],
-		Pct50:   arr[10],
-		Pct55:   arr[11],
-		Pct60:   arr[12],
-		Pct65:   arr[13],
-		Pct70:   arr[14],
-		Pct75:   arr[15],
-		Pct80:   arr[16],
-		Pct85:   arr[17],
-		Pct90:   arr[18],
-		Pct95:   arr[19],
-		Pct99:   arr[20],
-		Pct999:  arr[21],
-		Pct9999: arr[22],
-		Max:     arr[23],
+		Min:          arr[0],
+		Pct5:         arr[1],
+		Pct10:        arr[2],
+		Pct15:        arr[3],
+		Pct20:        arr[4],
+		Pct25:        arr[5],
+		Pct30:        arr[6],
+		Pct35:        arr[7],
+		Pct40:        arr[8],
+		Pct45:        arr[9],
+		Pct50:        arr[10],
+		Pct55:        arr[11],
+		Pct60:        arr[12],
+		Pct65:        arr[13],
+		Pct70:        arr[14],
+		Pct75:        arr[15],
+		Pct80:        arr[16],
+		Pct85:        arr[17],
+		Pct90:        arr[18],
+		Pct95:        arr[19],
+		Pct99:        arr[20],
+		Pct999:       arr[21],
+		Pct9999:      arr[22],
+		Max:          arr[23],
+		TotalSamples: arr[24],
 	}
 
 }

--- a/ably/perf/perf_histogram_test.go
+++ b/ably/perf/perf_histogram_test.go
@@ -1,0 +1,615 @@
+package perf
+
+import (
+	"math/rand"
+	"sort"
+	"testing"
+)
+
+func TestNewHistogram(t *testing.T) {
+
+	t.Run("NewHistogram provides a 60s default", func(ts *testing.T) {
+		hist := NewDefaultHistogram()
+
+		for i := 0; i <= 60001; i++ {
+			hist.Add(int64(i))
+		}
+
+		expectedPercentiles := percentilesFromArray([]int64{
+			0,
+			3000,
+			6000,
+			9000,
+			12000,
+			15000,
+			18000,
+			21000,
+			24000,
+			27000,
+			30000,
+			33001,
+			36001,
+			39001,
+			42001,
+			45001,
+			48001,
+			51001,
+			54001,
+			57001,
+			59401,
+			59941,
+			59995,
+			60001,
+		})
+
+		percentiles := hist.Percentiles()
+
+		assertEqualPercentiles(ts, percentiles, expectedPercentiles)
+	})
+
+	t.Run("Histogram with bucket spacing works correctly", func(ts *testing.T) {
+		// Like the default, but with 5ms buckets instead of 1ms buckets
+		hist := NewHistogram(12000, 1, 5)
+
+		for i := 0; i <= 60001; i++ {
+			hist.Add(int64(i))
+		}
+
+		expectedPercentiles := percentilesFromArray([]int64{
+			0,
+			3000,
+			6000,
+			9000,
+			12000,
+			15000,
+			18000,
+			21000,
+			24000,
+			27000,
+			30000,
+			33005,
+			36005,
+			39005,
+			42005,
+			45005,
+			48005,
+			51005,
+			54005,
+			57005,
+			59405,
+			59945,
+			59995,
+			60001,
+		})
+
+		percentiles := hist.Percentiles()
+
+		assertEqualPercentiles(ts, percentiles, expectedPercentiles)
+	})
+
+	t.Run("Histogram with all samples below min", func(ts *testing.T) {
+		hist := NewDefaultHistogram()
+
+		for i := 0; i <= 60001; i++ {
+			hist.Add(-1 * int64(i))
+		}
+
+		expectedPercentiles := percentilesFromArray([]int64{
+			-60001,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+		})
+
+		percentiles := hist.Percentiles()
+
+		assertEqualPercentiles(ts, percentiles, expectedPercentiles)
+	})
+
+	t.Run("Histogram with all samples above max", func(ts *testing.T) {
+		hist := NewDefaultHistogram()
+
+		for i := 0; i <= 60001; i++ {
+			hist.Add(60001 + int64(i))
+		}
+
+		expectedPercentiles := percentilesFromArray([]int64{
+			60001,
+			120002,
+			120002,
+			120002,
+			120002,
+			120002,
+			120002,
+			120002,
+			120002,
+			120002,
+			120002,
+			120002,
+			120002,
+			120002,
+			120002,
+			120002,
+			120002,
+			120002,
+			120002,
+			120002,
+			120002,
+			120002,
+			120002,
+			120002,
+			120002,
+		})
+
+		percentiles := hist.Percentiles()
+
+		assertEqualPercentiles(ts, percentiles, expectedPercentiles)
+	})
+
+	t.Run("Empty percentile contains zeroes", func(ts *testing.T) {
+		hist := NewDefaultHistogram()
+		expectedPercentiles := &Percentiles{}
+		percentiles := hist.Percentiles()
+		assertEqualPercentiles(ts, percentiles, expectedPercentiles)
+	})
+
+	t.Run("Histogram max clamped", func(ts *testing.T) {
+		// Like the default, but with 5ms buckets instead of 1ms buckets
+		hist := NewHistogram(12000, 1, 5)
+
+		for i := 0; i <= 60001; i++ {
+			if i > 59994 {
+				hist.Add(59994)
+			} else {
+				hist.Add(int64(i))
+			}
+		}
+
+		expectedPercentiles := percentilesFromArray([]int64{
+			0,
+			3000,
+			6000,
+			9000,
+			12000,
+			15000,
+			18000,
+			21000,
+			24000,
+			27000,
+			30000,
+			33005,
+			36005,
+			39005,
+			42005,
+			45005,
+			48005,
+			51005,
+			54005,
+			57005,
+			59405,
+			59945,
+			59994,
+			59994,
+		})
+
+		percentiles := hist.Percentiles()
+
+		assertEqualPercentiles(ts, percentiles, expectedPercentiles)
+	})
+
+	t.Run("Histogram min values max clamped", func(ts *testing.T) {
+		// Like the default, but with 5ms buckets instead of 1ms buckets
+		hist := NewHistogram(4, 1, 5)
+
+		hist.Add(-6)
+		hist.Add(-12)
+
+		expectedPercentiles := percentilesFromArray([]int64{
+			-12,
+			-6,
+			-6,
+			-6,
+			-6,
+			-6,
+			-6,
+			-6,
+			-6,
+			-6,
+			-6,
+			-6,
+			-6,
+			-6,
+			-6,
+			-6,
+			-6,
+			-6,
+			-6,
+			-6,
+			-6,
+			-6,
+			-6,
+			-6,
+		})
+
+		percentiles := hist.Percentiles()
+
+		assertEqualPercentiles(ts, percentiles, expectedPercentiles)
+	})
+
+	t.Run("Histogram with negative samples", func(ts *testing.T) {
+		hist := NewHistogram(60000, -60000, 1)
+
+		for i := 0; i <= 60001; i++ {
+			hist.Add(-1 * int64(i))
+		}
+
+		expectedPercentiles := percentilesFromArray([]int64{
+			-60001,
+			-57001,
+			-54001,
+			-51001,
+			-48001,
+			-45001,
+			-42001,
+			-39001,
+			-36001,
+			-33001,
+			-30001,
+			-27000,
+			-24000,
+			-21000,
+			-18000,
+			-15000,
+			-12000,
+			-9000,
+			-6000,
+			-3000,
+			-600,
+			-60,
+			-6,
+			0,
+		})
+
+		percentiles := hist.Percentiles()
+
+		assertEqualPercentiles(ts, percentiles, expectedPercentiles)
+	})
+
+	t.Run("Histogram with negative width", func(ts *testing.T) {
+		hist := NewHistogram(12000, 60000, -5)
+
+		for i := 0; i <= 60001; i++ {
+			hist.Add(int64(i))
+		}
+
+		expectedPercentiles := percentilesFromArray([]int64{
+			0,
+			3000,
+			6000,
+			9000,
+			12000,
+			15000,
+			18000,
+			21000,
+			24000,
+			27000,
+			30000,
+			33005,
+			36005,
+			39005,
+			42005,
+			45005,
+			48005,
+			51005,
+			54005,
+			57005,
+			59405,
+			59945,
+			59995,
+			60001,
+		})
+
+		percentiles := hist.Percentiles()
+
+		assertEqualPercentiles(ts, percentiles, expectedPercentiles)
+	})
+}
+
+func TestNewHistogramSimulation(t *testing.T) {
+	t.Run("NewHistogram provides a 60s default", func(ts *testing.T) {
+		hist := NewDefaultHistogram()
+		samples := int64(1000000)
+
+		sampleLog := make([]int64, 0, samples)
+
+		for i := int64(0); i <= samples; i++ {
+			sample := int64(rand.Intn(60001))
+			hist.Add(sample)
+			sampleLog = append(sampleLog, sample)
+		}
+
+		sort.Slice(sampleLog, func(i, j int) bool {
+			return sampleLog[i] < sampleLog[j]
+		})
+
+		expectedPercentiles := percentilesFromArray([]int64{
+			sampleLog[0],
+			sampleLog[percentileToSamples(samples, 5, 100)],
+			sampleLog[percentileToSamples(samples, 10, 100)],
+			sampleLog[percentileToSamples(samples, 15, 100)],
+			sampleLog[percentileToSamples(samples, 20, 100)],
+			sampleLog[percentileToSamples(samples, 25, 100)],
+			sampleLog[percentileToSamples(samples, 30, 100)],
+			sampleLog[percentileToSamples(samples, 35, 100)],
+			sampleLog[percentileToSamples(samples, 40, 100)],
+			sampleLog[percentileToSamples(samples, 45, 100)],
+			sampleLog[percentileToSamples(samples, 50, 100)],
+			sampleLog[percentileToSamples(samples, 55, 100)],
+			sampleLog[percentileToSamples(samples, 60, 100)],
+			sampleLog[percentileToSamples(samples, 65, 100)],
+			sampleLog[percentileToSamples(samples, 70, 100)],
+			sampleLog[percentileToSamples(samples, 75, 100)],
+			sampleLog[percentileToSamples(samples, 80, 100)],
+			sampleLog[percentileToSamples(samples, 85, 100)],
+			sampleLog[percentileToSamples(samples, 90, 100)],
+			sampleLog[percentileToSamples(samples, 95, 100)],
+			sampleLog[percentileToSamples(samples, 99, 100)],
+			sampleLog[percentileToSamples(samples, 999, 1000)],
+			sampleLog[percentileToSamples(samples, 9999, 10000)],
+			sampleLog[samples-1],
+		})
+
+		percentiles := hist.Percentiles()
+
+		assertEqualPercentiles(ts, percentiles, expectedPercentiles)
+	})
+}
+
+func assertEqualPercentiles(
+	t *testing.T,
+	actual *Percentiles,
+	expected *Percentiles,
+) {
+	if actual.Min != expected.Min {
+		t.Errorf(
+			"unepxected percentile Max value, wanted: %d, got %d",
+			expected.Max,
+			actual.Max,
+		)
+	}
+
+	if actual.Pct5 != expected.Pct5 {
+		t.Errorf(
+			"unepxected percentile Pct5 value, wanted: %d, got %d",
+			expected.Pct5,
+			actual.Pct5,
+		)
+	}
+
+	if actual.Pct10 != expected.Pct10 {
+		t.Errorf(
+			"unepxected percentile Pct10 value, wanted: %d, got %d",
+			expected.Pct10,
+			actual.Pct10,
+		)
+	}
+
+	if actual.Pct15 != expected.Pct15 {
+		t.Errorf(
+			"unepxected percentile Pct15 value, wanted: %d, got %d",
+			expected.Pct15,
+			actual.Pct15,
+		)
+	}
+
+	if actual.Pct20 != expected.Pct20 {
+		t.Errorf(
+			"unepxected percentile Pct20 value, wanted: %d, got %d",
+			expected.Pct20,
+			actual.Pct20,
+		)
+	}
+
+	if actual.Pct25 != expected.Pct25 {
+		t.Errorf(
+			"unepxected percentile Pct25 value, wanted: %d, got %d",
+			expected.Pct25,
+			actual.Pct25,
+		)
+	}
+
+	if actual.Pct30 != expected.Pct30 {
+		t.Errorf(
+			"unepxected percentile Pct30 value, wanted: %d, got %d",
+			expected.Pct30,
+			actual.Pct30,
+		)
+	}
+
+	if actual.Pct35 != expected.Pct35 {
+		t.Errorf(
+			"unepxected percentile Pct35 value, wanted: %d, got %d",
+			expected.Pct35,
+			actual.Pct35,
+		)
+	}
+
+	if actual.Pct40 != expected.Pct40 {
+		t.Errorf(
+			"unepxected percentile Pct40 value, wanted: %d, got %d",
+			expected.Pct40,
+			actual.Pct40,
+		)
+	}
+
+	if actual.Pct45 != expected.Pct45 {
+		t.Errorf(
+			"unepxected percentile Pct45 value, wanted: %d, got %d",
+			expected.Pct45,
+			actual.Pct45,
+		)
+	}
+
+	if actual.Pct50 != expected.Pct50 {
+		t.Errorf(
+			"unepxected percentile Pct50 value, wanted: %d, got %d",
+			expected.Pct50,
+			actual.Pct50,
+		)
+	}
+
+	if actual.Pct55 != expected.Pct55 {
+		t.Errorf(
+			"unepxected percentile Pct55 value, wanted: %d, got %d",
+			expected.Pct55,
+			actual.Pct55,
+		)
+	}
+
+	if actual.Pct60 != expected.Pct60 {
+		t.Errorf(
+			"unepxected percentile Pct60 value, wanted: %d, got %d",
+			expected.Pct60,
+			actual.Pct60,
+		)
+	}
+
+	if actual.Pct65 != expected.Pct65 {
+		t.Errorf(
+			"unepxected percentile Pct65 value, wanted: %d, got %d",
+			expected.Pct65,
+			actual.Pct65,
+		)
+	}
+
+	if actual.Pct70 != expected.Pct70 {
+		t.Errorf(
+			"unepxected percentile Pct70 value, wanted: %d, got %d",
+			expected.Pct70,
+			actual.Pct70,
+		)
+	}
+
+	if actual.Pct75 != expected.Pct75 {
+		t.Errorf(
+			"unepxected percentile Pct75 value, wanted: %d, got %d",
+			expected.Pct75,
+			actual.Pct75,
+		)
+	}
+
+	if actual.Pct80 != expected.Pct80 {
+		t.Errorf(
+			"unepxected percentile Pct80 value, wanted: %d, got %d",
+			expected.Pct80,
+			actual.Pct80,
+		)
+	}
+
+	if actual.Pct85 != expected.Pct85 {
+		t.Errorf(
+			"unepxected percentile Pct85 value, wanted: %d, got %d",
+			expected.Pct85,
+			actual.Pct85,
+		)
+	}
+
+	if actual.Pct90 != expected.Pct90 {
+		t.Errorf(
+			"unepxected percentile Pct90 value, wanted: %d, got %d",
+			expected.Pct90,
+			actual.Pct90,
+		)
+	}
+
+	if actual.Pct95 != expected.Pct95 {
+		t.Errorf(
+			"unepxected percentile 95 value, wanted: %d, got %d",
+			expected.Pct95,
+			actual.Pct95,
+		)
+	}
+
+	if actual.Pct99 != expected.Pct99 {
+		t.Errorf(
+			"unepxected percentile Pct99 value, wanted: %d, got %d",
+			expected.Pct99,
+			actual.Pct99,
+		)
+	}
+
+	if actual.Pct999 != expected.Pct999 {
+		t.Errorf(
+			"unepxected percentile Pct999 value, wanted: %d, got %d",
+			expected.Pct999,
+			actual.Pct999,
+		)
+	}
+
+	if actual.Pct9999 != expected.Pct9999 {
+		t.Errorf(
+			"unepxected percentile Pct9999 value, wanted: %d, got %d",
+			expected.Pct9999,
+			actual.Pct9999,
+		)
+	}
+
+	if actual.Max != expected.Max {
+		t.Errorf(
+			"unepxected percentile Max value, wanted: %d, got %d",
+			expected.Max,
+			actual.Max,
+		)
+	}
+}
+
+func percentilesFromArray(arr []int64) *Percentiles {
+	return &Percentiles{
+		Min:     arr[0],
+		Pct5:    arr[1],
+		Pct10:   arr[2],
+		Pct15:   arr[3],
+		Pct20:   arr[4],
+		Pct25:   arr[5],
+		Pct30:   arr[6],
+		Pct35:   arr[7],
+		Pct40:   arr[8],
+		Pct45:   arr[9],
+		Pct50:   arr[10],
+		Pct55:   arr[11],
+		Pct60:   arr[12],
+		Pct65:   arr[13],
+		Pct70:   arr[14],
+		Pct75:   arr[15],
+		Pct80:   arr[16],
+		Pct85:   arr[17],
+		Pct90:   arr[18],
+		Pct95:   arr[19],
+		Pct99:   arr[20],
+		Pct999:  arr[21],
+		Pct9999: arr[22],
+		Max:     arr[23],
+	}
+
+}

--- a/ably/perf/perf_test.go
+++ b/ably/perf/perf_test.go
@@ -92,7 +92,7 @@ func TestPerfPProf(t *testing.T) {
 
 		// S3 ACL
 		acl := s3Client.input.ACL
-		expectedACL := "private"
+		expectedACL := "authenticated-read"
 		if acl == nil {
 			ts.Errorf("missing s3 file ACL")
 		} else if *acl != expectedACL {
@@ -331,7 +331,7 @@ func TestPerfHistogram(t *testing.T) {
 
 		// S3 ACL
 		acl := s3Client.input.ACL
-		expectedACL := "private"
+		expectedACL := "authenticated-read"
 		if acl == nil {
 			ts.Errorf("missing s3 file ACL")
 		} else if *acl != expectedACL {

--- a/ably/perf/perf_test.go
+++ b/ably/perf/perf_test.go
@@ -13,8 +13,8 @@ import (
 func TestPerfPProf(t *testing.T) {
 	t.Run("pprof works with sensible defaults", func(ts *testing.T) {
 		var testEnv testEnvMap = map[string]string{
-			"PERF_CPU_PROFILE_DIR": os.TempDir(),
-			"PERF_CPU_S3_BUCKET":   "ably-logs-dev",
+			"PERF_CPU_PROFILE_DIR":       os.TempDir(),
+			"PERF_CPU_PROFILE_S3_BUCKET": "ably-logs-dev",
 		}
 
 		config, configErr := NewConfig(testEnv.LookupEnv)
@@ -203,10 +203,10 @@ func TestPerfPProf(t *testing.T) {
 			)
 		}
 
-		bucket, bucketSet := os.LookupEnv("PERF_CPU_S3_BUCKET")
+		bucket, bucketSet := os.LookupEnv("PERF_CPU_PROFILE_S3_BUCKET")
 		if bucketSet && bucket != "" {
 			ts.Fatalf(
-				"PERF_CPU_S3_BUCKET env is currently set: %s",
+				"PERF_CPU_PROFILE_S3_BUCKET env is currently set: %s",
 				bucket,
 			)
 		}
@@ -230,8 +230,8 @@ func TestPerfPProf(t *testing.T) {
 
 	t.Run("pprof defaults to real s3 client", func(ts *testing.T) {
 		var testEnv testEnvMap = map[string]string{
-			"PERF_CPU_PROFILE_DIR": os.TempDir(),
-			"PERF_CPU_S3_BUCKET":   "ably-logs-dev",
+			"PERF_CPU_PROFILE_DIR":       os.TempDir(),
+			"PERF_CPU_PROFILE_S3_BUCKET": "ably-logs-dev",
 		}
 
 		config, configErr := NewConfig(testEnv.LookupEnv)

--- a/ably/perf/perf_test.go
+++ b/ably/perf/perf_test.go
@@ -90,7 +90,7 @@ func TestPerfPProf(t *testing.T) {
 			)
 		}
 
-		// S3 ACL
+		/* S3 ACL
 		acl := s3Client.input.ACL
 		expectedACL := "authenticated-read"
 		if acl == nil {
@@ -101,7 +101,7 @@ func TestPerfPProf(t *testing.T) {
 				*acl,
 				expectedACL,
 			)
-		}
+		} */
 
 		// S3 Body
 		s3File, s3FileOk := s3Client.input.Body.(*os.File)
@@ -329,7 +329,7 @@ func TestPerfHistogram(t *testing.T) {
 			)
 		}
 
-		// S3 ACL
+		/* S3 ACL
 		acl := s3Client.input.ACL
 		expectedACL := "authenticated-read"
 		if acl == nil {
@@ -340,7 +340,7 @@ func TestPerfHistogram(t *testing.T) {
 				*acl,
 				expectedACL,
 			)
-		}
+		} */
 
 		// S3 Body
 		s3File, s3FileOk := s3Client.input.Body.(*os.File)

--- a/ably/perf/perf_test.go
+++ b/ably/perf/perf_test.go
@@ -23,13 +23,13 @@ func TestNewPerf(t *testing.T) {
 
 		s3Client := &mockS3{}
 
-		perf := NewWithS3(config, s3Client)
+		perf := NewReporterWithS3(config, s3Client)
 		perf.Start()
 		defer func() {
 			err := perf.Stop()
 			// Cleanup the pprof file if we can
-			if path.Ext(perf.fileName) == ".pprof" {
-				os.Remove(perf.fileName)
+			if path.Ext(perf.pprofFileName) == ".pprof" {
+				os.Remove(perf.pprofFileName)
 			}
 			if err != nil {
 				ts.Fatalf("error stopping perf: %s", err)
@@ -44,7 +44,7 @@ func TestNewPerf(t *testing.T) {
 		}
 
 		// Test that a cpuprofile was written to disk
-		fileExt := path.Ext(perf.fileName)
+		fileExt := path.Ext(perf.pprofFileName)
 		expectedFileExt := ".pprof"
 		if fileExt != expectedFileExt {
 			ts.Fatalf(
@@ -53,7 +53,7 @@ func TestNewPerf(t *testing.T) {
 				expectedFileExt,
 			)
 		}
-		pprofStat, pprofStatErr := os.Stat(perf.fileName)
+		pprofStat, pprofStatErr := os.Stat(perf.pprofFileName)
 		if pprofStatErr != nil {
 			ts.Fatalf(
 				"pprof file missing from disk: %s",
@@ -83,7 +83,10 @@ func TestNewPerf(t *testing.T) {
 
 		// S3 Key
 		key := s3Client.input.Key
-		expectedKey := path.Join(defaultKeyPrefix, path.Base(perf.fileName))
+		expectedKey := path.Join(
+			_defaultKeyPrefix,
+			path.Base(perf.pprofFileName),
+		)
 		if key == nil {
 			ts.Errorf("missing key in s3 client options")
 		} else if *key != expectedKey {
@@ -111,11 +114,11 @@ func TestNewPerf(t *testing.T) {
 		s3File, s3FileOk := s3Client.input.Body.(*os.File)
 		if !s3FileOk || s3File == nil {
 			ts.Errorf("missing file as s3 PutObject body")
-		} else if s3File.Name() != perf.fileName {
+		} else if s3File.Name() != perf.pprofFileName {
 			ts.Errorf(
 				"unexpected s3 file upload, got: %s, wanted: %s",
 				s3File.Name(),
-				perf.fileName,
+				perf.pprofFileName,
 			)
 		}
 
@@ -158,13 +161,13 @@ func TestNewPerf(t *testing.T) {
 
 		s3Client := &mockS3{}
 
-		perf := NewWithS3(config, s3Client)
+		perf := NewReporterWithS3(config, s3Client)
 		perf.Start()
 		defer func() {
 			err := perf.Stop()
 			// Cleanup the pprof file if we can
-			if path.Ext(perf.fileName) == ".pprof" {
-				os.Remove(perf.fileName)
+			if path.Ext(perf.pprofFileName) == ".pprof" {
+				os.Remove(perf.pprofFileName)
 			}
 			if err != nil {
 				ts.Fatalf("error stopping perf: %s", err)
@@ -179,7 +182,7 @@ func TestNewPerf(t *testing.T) {
 		}
 
 		// Test that a cpuprofile was written to disk
-		fileExt := path.Ext(perf.fileName)
+		fileExt := path.Ext(perf.pprofFileName)
 		expectedFileExt := ".pprof"
 		if fileExt != expectedFileExt {
 			ts.Fatalf(
@@ -188,7 +191,7 @@ func TestNewPerf(t *testing.T) {
 				expectedFileExt,
 			)
 		}
-		pprofStat, pprofStatErr := os.Stat(perf.fileName)
+		pprofStat, pprofStatErr := os.Stat(perf.pprofFileName)
 		if pprofStatErr != nil {
 			ts.Fatalf(
 				"pprof file missing from disk: %s",
@@ -222,13 +225,13 @@ func TestNewPerf(t *testing.T) {
 			)
 		}
 
-		perf := New()
+		perf := NewReporter()
 		perf.Start()
 		defer func() {
 			err := perf.Stop()
 			// Cleanup the pprof file if we can
-			if path.Ext(perf.fileName) == ".pprof" {
-				os.Remove(perf.fileName)
+			if path.Ext(perf.pprofFileName) == ".pprof" {
+				os.Remove(perf.pprofFileName)
 			}
 			if err != nil {
 				ts.Fatalf("error stopping perf: %s", err)
@@ -243,7 +246,7 @@ func TestNewPerf(t *testing.T) {
 		}
 
 		// Test that a cpuprofile is not taken by default
-		if perf.fileName != "" {
+		if perf.pprofFileName != "" {
 			ts.Fatalf("expected no pprof file by default")
 		}
 	})
@@ -259,7 +262,7 @@ func TestNewPerf(t *testing.T) {
 			ts.Fatalf("failed to initialize perf config: %s", configErr)
 		}
 
-		perf := NewWithS3(config, nil)
+		perf := NewReporterWithS3(config, nil)
 
 		configuredS3Client, configuredS3ClientErr := perf.configuredS3Client()
 		if configuredS3ClientErr != nil {

--- a/ably/perf/perf_test.go
+++ b/ably/perf/perf_test.go
@@ -1,6 +1,7 @@
 package perf
 
 import (
+	"math/rand"
 	"os"
 	"path"
 	"testing"
@@ -9,8 +10,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 )
 
-func TestNewPerf(t *testing.T) {
-	t.Run("perf works with sensible defaults", func(ts *testing.T) {
+func TestPerfPProf(t *testing.T) {
+	t.Run("pprof works with sensible defaults", func(ts *testing.T) {
 		var testEnv testEnvMap = map[string]string{
 			"PERF_CPU_PROFILE_DIR": os.TempDir(),
 			"PERF_CPU_S3_BUCKET":   "ably-logs-dev",
@@ -21,20 +22,12 @@ func TestNewPerf(t *testing.T) {
 			ts.Fatalf("failed to initialize perf config: %s", configErr)
 		}
 
+		reporter := &mockBoomer{}
 		s3Client := &mockS3{}
 
-		perf := NewReporterWithS3(config, s3Client)
+		perf := NewReporter(config, reporter, s3Client)
 		perf.Start()
-		defer func() {
-			err := perf.Stop()
-			// Cleanup the pprof file if we can
-			if path.Ext(perf.pprofFileName) == ".pprof" {
-				os.Remove(perf.pprofFileName)
-			}
-			if err != nil {
-				ts.Fatalf("error stopping perf: %s", err)
-			}
-		}()
+		defer cleanup(ts, perf)
 
 		time.Sleep(100 * time.Millisecond)
 
@@ -84,7 +77,7 @@ func TestNewPerf(t *testing.T) {
 		// S3 Key
 		key := s3Client.input.Key
 		expectedKey := path.Join(
-			_defaultKeyPrefix,
+			_defaultPprofKeyPrefix,
 			path.Base(perf.pprofFileName),
 		)
 		if key == nil {
@@ -149,7 +142,7 @@ func TestNewPerf(t *testing.T) {
 		}
 	})
 
-	t.Run("perf does not write to s3 unless configured", func(ts *testing.T) {
+	t.Run("pprof does not write to s3 unless configured", func(ts *testing.T) {
 		var testEnv testEnvMap = map[string]string{
 			"PERF_CPU_PROFILE_DIR": os.TempDir(),
 		}
@@ -159,20 +152,13 @@ func TestNewPerf(t *testing.T) {
 			ts.Fatalf("failed to initialize perf config: %s", configErr)
 		}
 
+		reporter := &mockBoomer{}
+
 		s3Client := &mockS3{}
 
-		perf := NewReporterWithS3(config, s3Client)
+		perf := NewReporter(config, reporter, s3Client)
 		perf.Start()
-		defer func() {
-			err := perf.Stop()
-			// Cleanup the pprof file if we can
-			if path.Ext(perf.pprofFileName) == ".pprof" {
-				os.Remove(perf.pprofFileName)
-			}
-			if err != nil {
-				ts.Fatalf("error stopping perf: %s", err)
-			}
-		}()
+		defer cleanup(ts, perf)
 
 		time.Sleep(100 * time.Millisecond)
 
@@ -207,7 +193,7 @@ func TestNewPerf(t *testing.T) {
 		}
 	})
 
-	t.Run("perf doesn't run by default", func(ts *testing.T) {
+	t.Run("pprof doesn't run by default", func(ts *testing.T) {
 		// Check that the environment doesn't contain perf configuration
 		profileDir, profileDirSet := os.LookupEnv("PERF_CPU_PROFILE_DIR")
 		if profileDirSet && profileDir != "" {
@@ -225,18 +211,9 @@ func TestNewPerf(t *testing.T) {
 			)
 		}
 
-		perf := NewReporter()
+		perf := NewDefaultReporter()
 		perf.Start()
-		defer func() {
-			err := perf.Stop()
-			// Cleanup the pprof file if we can
-			if path.Ext(perf.pprofFileName) == ".pprof" {
-				os.Remove(perf.pprofFileName)
-			}
-			if err != nil {
-				ts.Fatalf("error stopping perf: %s", err)
-			}
-		}()
+		defer cleanup(ts, perf)
 
 		time.Sleep(100 * time.Millisecond)
 
@@ -251,7 +228,7 @@ func TestNewPerf(t *testing.T) {
 		}
 	})
 
-	t.Run("perf defaults to real s3 client", func(ts *testing.T) {
+	t.Run("pprof defaults to real s3 client", func(ts *testing.T) {
 		var testEnv testEnvMap = map[string]string{
 			"PERF_CPU_PROFILE_DIR": os.TempDir(),
 			"PERF_CPU_S3_BUCKET":   "ably-logs-dev",
@@ -262,7 +239,7 @@ func TestNewPerf(t *testing.T) {
 			ts.Fatalf("failed to initialize perf config: %s", configErr)
 		}
 
-		perf := NewReporterWithS3(config, nil)
+		perf := NewReporter(config, nil, nil)
 
 		configuredS3Client, configuredS3ClientErr := perf.configuredS3Client()
 		if configuredS3ClientErr != nil {
@@ -277,6 +254,329 @@ func TestNewPerf(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestPerfHistogram(t *testing.T) {
+	t.Run("histograms work with sensible defaults", func(ts *testing.T) {
+		var testEnv testEnvMap = map[string]string{
+			"PERF_HISTOGRAM_DIR":       os.TempDir(),
+			"PERF_HISTOGRAM_S3_BUCKET": "ably-logs-dev",
+		}
+
+		config, configErr := NewConfig(testEnv.LookupEnv)
+		if configErr != nil {
+			ts.Fatalf("failed to initialize perf config: %s", configErr)
+		}
+
+		reporter := &mockBoomer{}
+		s3Client := &mockS3{}
+
+		perf := NewReporter(config, reporter, s3Client)
+		perf.Start()
+		defer cleanup(ts, perf)
+
+		expectedHistMap := writeTestRecords(perf, 100)
+
+		perfErr := perf.Stop()
+		if perfErr != nil {
+			ts.Fatalf("error stopping perf: %s", perfErr)
+		}
+
+		// Test that the histograms are as expected
+		assertEqualHistogramFile(ts, perf.histFileName, expectedHistMap)
+
+		// Test that the pprof file was uploaded to the ably-logs-dev s3 bucket
+		histStat, histStatErr := os.Stat(perf.histFileName)
+		if histStatErr != nil {
+			t.Fatalf(
+				"histogram file missing from disk: %s",
+				histStatErr,
+			)
+		} else if histStat.Size() == 0 {
+			t.Fatalf("histogram file is empty")
+		}
+
+		if s3Client.input == nil {
+			ts.Fatalf("s3 PutObject was not called")
+		}
+
+		// S3 Bucket
+		bucket := s3Client.input.Bucket
+		expectedBucket := "ably-logs-dev"
+		if bucket == nil {
+			ts.Errorf("missing bucket name is s3 client options")
+		} else if *bucket != expectedBucket {
+			ts.Errorf(
+				"unexpected s3 bucket, got: %s, wanted: %s",
+				*bucket,
+				expectedBucket,
+			)
+		}
+
+		// S3 Key
+		key := s3Client.input.Key
+		expectedKey := path.Join(
+			_defaultHistKeyPrefix,
+			path.Base(perf.histFileName),
+		)
+		if key == nil {
+			ts.Errorf("missing key in s3 client options")
+		} else if *key != expectedKey {
+			ts.Errorf(
+				"unexpected s3 key, got: %s, wanted: %s",
+				*key,
+				expectedKey,
+			)
+		}
+
+		// S3 ACL
+		acl := s3Client.input.ACL
+		expectedACL := "private"
+		if acl == nil {
+			ts.Errorf("missing s3 file ACL")
+		} else if *acl != expectedACL {
+			ts.Errorf(
+				"unexpected s3 file ACL, got: %s, wanted: %s",
+				*acl,
+				expectedACL,
+			)
+		}
+
+		// S3 Body
+		s3File, s3FileOk := s3Client.input.Body.(*os.File)
+		if !s3FileOk || s3File == nil {
+			ts.Errorf("missing file as s3 PutObject body")
+		} else if s3File.Name() != perf.histFileName {
+			ts.Errorf(
+				"unexpected s3 file upload, got: %s, wanted: %s",
+				s3File.Name(),
+				perf.pprofFileName,
+			)
+		}
+
+		// S3 ContentLength
+		s3ContentLength := s3Client.input.ContentLength
+		expectedS3ContentLength := histStat.Size()
+		if s3ContentLength == nil {
+			ts.Errorf("missing s3 file content length")
+		} else if *s3ContentLength != expectedS3ContentLength {
+			ts.Errorf(
+				"unexpected s3 content length: got %d, wanted %d",
+				*s3ContentLength,
+				expectedS3ContentLength,
+			)
+		}
+
+		// S3 ContentType
+		s3ContentType := s3Client.input.ContentType
+		expectedS3ContentType := "application/octet-stream"
+		if s3ContentType == nil {
+			ts.Errorf("missing content type in s3 client options")
+		} else if *s3ContentType != expectedS3ContentType {
+			ts.Errorf(
+				"unexpected s3 content type, got: %s, wanted: %s",
+				*s3ContentType,
+				expectedS3ContentType,
+			)
+		}
+	})
+
+	t.Run("hist does not write to s3 unless configured", func(ts *testing.T) {
+		var testEnv testEnvMap = map[string]string{
+			"PERF_HISTOGRAM_DIR": os.TempDir(),
+		}
+
+		config, configErr := NewConfig(testEnv.LookupEnv)
+		if configErr != nil {
+			ts.Fatalf("failed to initialize perf config: %s", configErr)
+		}
+
+		reporter := &mockBoomer{}
+
+		s3Client := &mockS3{}
+
+		perf := NewReporter(config, reporter, s3Client)
+		perf.Start()
+		defer cleanup(ts, perf)
+
+		expectedHistMap := writeTestRecords(perf, 100)
+
+		perfErr := perf.Stop()
+		if perfErr != nil {
+			ts.Fatalf("error stopping perf: %s", perfErr)
+		}
+
+		assertEqualHistogramFile(ts, perf.histFileName, expectedHistMap)
+
+		// Test that the pprof file was uploaded to the ably-logs-dev s3 bucket
+		if s3Client.input != nil {
+			ts.Fatalf("s3 PutObject should not be called")
+		}
+	})
+
+	t.Run("histogram doesn't run by default", func(ts *testing.T) {
+		// Check that the environment doesn't contain perf configuration
+		profileDir, profileDirSet := os.LookupEnv("PERF_HISTOGRAM_DIR")
+		if profileDirSet && profileDir != "" {
+			ts.Fatalf(
+				"PERF_HISTOGRAM_DIR env is currently set: %s",
+				profileDir,
+			)
+		}
+
+		bucket, bucketSet := os.LookupEnv("PERF_HISTOGRAM_S3_BUCKET")
+		if bucketSet && bucket != "" {
+			ts.Fatalf(
+				"PERF_HISTOGRAM_S3_BUCKET env is currently set: %s",
+				bucket,
+			)
+		}
+
+		perf := NewDefaultReporter()
+		perf.Start()
+		defer cleanup(ts, perf)
+
+		time.Sleep(100 * time.Millisecond)
+
+		perfErr := perf.Stop()
+		if perfErr != nil {
+			ts.Fatalf("error stopping perf: %s", perfErr)
+		}
+
+		// Test that a cpuprofile is not taken by default
+		if perf.pprofFileName != "" {
+			ts.Fatalf("expected no pprof file by default")
+		}
+	})
+
+	t.Run("histogram defaults to real s3 client", func(ts *testing.T) {
+		var testEnv testEnvMap = map[string]string{
+			"PERF_HISTOGRAM_DIR":    os.TempDir(),
+			"PERF_HISTOGRAM_BUCKET": "ably-logs-dev",
+		}
+
+		config, configErr := NewConfig(testEnv.LookupEnv)
+		if configErr != nil {
+			ts.Fatalf("failed to initialize perf config: %s", configErr)
+		}
+
+		perf := NewReporter(config, nil, nil)
+
+		configuredS3Client, configuredS3ClientErr := perf.configuredS3Client()
+		if configuredS3ClientErr != nil {
+			ts.Fatalf(
+				"unexpected error getting s3 client: %s",
+				configuredS3ClientErr,
+			)
+		} else {
+			s3Client, s3ClientOK := configuredS3Client.(*s3.S3)
+			if !s3ClientOK || s3Client == nil {
+				ts.Fatalf("expected s3 client to default to a real client")
+			}
+		}
+	})
+}
+
+func writeTestRecords(r LocustReporter, count int) map[string]*Histogram {
+	expectedHistMap := map[string]*Histogram{}
+
+	for i := 0; i < 100; i++ {
+		roundTripTime := int64(rand.Intn(60001))
+		failureTime := int64(rand.Intn(60001))
+		r.RecordSuccess("ably", "subscribe", roundTripTime, 100)
+		r.RecordFailure("ably", "subscribe", failureTime, "testing")
+
+		sHist, ok := expectedHistMap["ably.subscribe.success"]
+		if !ok {
+			sHist = NewDefaultHistogram()
+			expectedHistMap["ably.subscribe.success"] = sHist
+		}
+		sHist.Add(roundTripTime)
+
+		fHist, ok := expectedHistMap["ably.subscribe.failure"]
+		if !ok {
+			fHist = NewDefaultHistogram()
+			expectedHistMap["ably.subscribe.failure"] = fHist
+		}
+		fHist.Add(failureTime)
+	}
+
+	return expectedHistMap
+}
+
+// Mock boomer records the success and failure calls by default
+type mockBoomer struct {
+	success []*mockBoomerSuccess
+	failure []*mockBoomerFailure
+}
+
+func (b *mockBoomer) RecordSuccess(
+	requestType string,
+	name string,
+	responseTime int64,
+	responseLength int64,
+) {
+	b.success = append(b.success, newMockBoomerSuccess(
+		requestType,
+		name,
+		responseTime,
+		responseLength,
+	))
+}
+func (b *mockBoomer) RecordFailure(
+	requestType string,
+	name string,
+	responseTime int64,
+	exception string,
+) {
+	b.failure = append(b.failure, newMockBoomerFailure(
+		requestType,
+		name,
+		responseTime,
+		exception,
+	))
+}
+
+type mockBoomerSuccess struct {
+	requestType    string
+	name           string
+	responseTime   int64
+	responseLength int64
+}
+
+func newMockBoomerSuccess(
+	requestType string,
+	name string,
+	responseTime int64,
+	responseLength int64,
+) *mockBoomerSuccess {
+	return &mockBoomerSuccess{
+		requestType,
+		name,
+		responseTime,
+		responseLength,
+	}
+}
+
+type mockBoomerFailure struct {
+	requestType  string
+	name         string
+	responseTime int64
+	exception    string
+}
+
+func newMockBoomerFailure(
+	requestType string,
+	name string,
+	responseTime int64,
+	exception string,
+) *mockBoomerFailure {
+	return &mockBoomerFailure{
+		requestType,
+		name,
+		responseTime,
+		exception,
+	}
 }
 
 type mockS3 struct {
@@ -294,4 +594,18 @@ func (s *mockS3) PutObject(
 	}
 
 	return s.output, nil
+}
+
+func cleanup(t *testing.T, perf *Reporter) {
+	err := perf.Stop()
+	// Cleanup the pprof file if we can
+	if path.Ext(perf.pprofFileName) == ".pprof" {
+		os.Remove(perf.pprofFileName)
+	}
+	if path.Ext(perf.histFileName) == ".hist" {
+		os.Remove(perf.histFileName)
+	}
+	if err != nil {
+		t.Fatalf("error stopping perf: %s", err)
+	}
 }

--- a/ably/perf/reporter.go
+++ b/ably/perf/reporter.go
@@ -1,0 +1,64 @@
+package perf
+
+import "github.com/ably-forks/boomer"
+
+// DefaultLocustReporter provides a default client for reporting to locust.
+// In this case it uses the default boomer client.
+var _defaultBoomerReporter LocustReporter = LocustReporter(
+	&DefaultBoomerReporter{},
+)
+
+// LocustReporter reports success and failure events to locust.
+type LocustReporter interface {
+	RecordSuccess(
+		requestType string,
+		name string,
+		responseTime int64,
+		responseLength int64,
+	)
+
+	RecordFailure(
+		requestType string,
+		name string,
+		responseTime int64,
+		exception string,
+	)
+}
+
+// DefaultLocustReporter gets the locust reporter global default
+func DefaultLocustReporter() LocustReporter {
+	return LocustReporter(_defaultBoomerReporter)
+}
+
+// DefaultBoomerReporter reports to locust with the default boomer client
+type DefaultBoomerReporter struct{}
+
+// RecordSuccess reports a success event to locust.
+func (*DefaultBoomerReporter) RecordSuccess(
+	requestType string,
+	name string,
+	responseTime int64,
+	responseLength int64,
+) {
+	boomer.RecordSuccess(
+		requestType,
+		name,
+		responseTime,
+		responseLength,
+	)
+}
+
+// RecordFailure reports a failure to locust.
+func (*DefaultBoomerReporter) RecordFailure(
+	requestType string,
+	name string,
+	responseTime int64,
+	exception string,
+) {
+	boomer.RecordFailure(
+		requestType,
+		name,
+		responseTime,
+		exception,
+	)
+}

--- a/ably/report_sub_to_locust.go
+++ b/ably/report_sub_to_locust.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ably/ably-go/ably"
 )
 
-func reportSubscriptionToLocust(ctx context.Context, perf *perf.Reporter, sub *ably.Subscription, conn *ably.Conn, errorChannel chan<- error) {
+func reportSubscriptionToLocust(ctx context.Context, l perf.LocustReporter, sub *ably.Subscription, conn *ably.Conn, errorChannel chan<- error) {
 	connectionStateChannel := make(chan ably.State)
 	conn.On(connectionStateChannel)
 
@@ -30,7 +30,7 @@ func reportSubscriptionToLocust(ctx context.Context, perf *perf.Reporter, sub *a
 			} else if connState.State == ably.StateConnConnected && lastDisconnectTime != 0 {
 				timeDisconnected := millisecondTimestamp() - lastDisconnectTime
 
-				perf.RecordSuccess("ably", "reconnect", timeDisconnected, 0)
+				l.RecordSuccess("ably", "reconnect", timeDisconnected, 0)
 			}
 		case <-ctx.Done():
 			return
@@ -44,14 +44,14 @@ func reportSubscriptionToLocust(ctx context.Context, perf *perf.Reporter, sub *a
 			timePublished, err := strconv.ParseInt(msg.Name, 10, 64)
 
 			if err != nil {
-				perf.RecordFailure("ably", "subscribe", 0, err.Error())
+				l.RecordFailure("ably", "subscribe", 0, err.Error())
 				break
 			}
 
 			timeElapsed := millisecondTimestamp() - timePublished
 			bytes := len(fmt.Sprint(msg.Data))
 
-			perf.RecordSuccess("ably", "subscribe", timeElapsed, int64(bytes))
+			l.RecordSuccess("ably", "subscribe", timeElapsed, int64(bytes))
 		}
 	}
 }

--- a/ably/report_sub_to_locust.go
+++ b/ably/report_sub_to_locust.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/ably-forks/boomer"
+	"github.com/ably/ably-boomer/ably/perf"
 	"github.com/ably/ably-go/ably"
 )
 
-func reportSubscriptionToLocust(ctx context.Context, sub *ably.Subscription, conn *ably.Conn, errorChannel chan<- error) {
+func reportSubscriptionToLocust(ctx context.Context, perf *perf.Reporter, sub *ably.Subscription, conn *ably.Conn, errorChannel chan<- error) {
 	connectionStateChannel := make(chan ably.State)
 	conn.On(connectionStateChannel)
 
@@ -30,7 +30,7 @@ func reportSubscriptionToLocust(ctx context.Context, sub *ably.Subscription, con
 			} else if connState.State == ably.StateConnConnected && lastDisconnectTime != 0 {
 				timeDisconnected := millisecondTimestamp() - lastDisconnectTime
 
-				boomer.RecordSuccess("ably", "reconnect", timeDisconnected, 0)
+				perf.RecordSuccess("ably", "reconnect", timeDisconnected, 0)
 			}
 		case <-ctx.Done():
 			return
@@ -44,14 +44,14 @@ func reportSubscriptionToLocust(ctx context.Context, sub *ably.Subscription, con
 			timePublished, err := strconv.ParseInt(msg.Name, 10, 64)
 
 			if err != nil {
-				boomer.RecordFailure("ably", "subscribe", 0, err.Error())
+				perf.RecordFailure("ably", "subscribe", 0, err.Error())
 				break
 			}
 
 			timeElapsed := millisecondTimestamp() - timePublished
 			bytes := len(fmt.Sprint(msg.Data))
 
-			boomer.RecordSuccess("ably", "subscribe", timeElapsed, int64(bytes))
+			perf.RecordSuccess("ably", "subscribe", timeElapsed, int64(bytes))
 		}
 	}
 }


### PR DESCRIPTION
This is the first pass at adding the latency histogram recording to this codebase.

Note that the following is required before landing:

  - ~~Tests~~
  - ~~Encode method (probably gob encoding)~~ histograms are gob encoded with an ID
  - ~~Some way to combine the histograms~~ printing the histograms in a later PR

A quick overview of how this works:

  - This histogram is configured with a minimum value and a width i.e. min: 1, bucketCount: 4, bucketWidth: 5 produces

```   
       Bucket:       - 0 -           - 1 -              - 2 -                - 3 -
Sample values: [ 1, 2, 3, 4, 5 | 6, 7, 8, 9, 10 | 11, 12, 13, 14, 15 | 16, 17, 18, 19, 20 ]
```

  - When a sample is added to the histogram it either goes into the corresponding bucket (i.e 3 goes into bucket 0, 18 goes goes into bucket 3, etc)

  - Values less than 1 are tallied in a `lowSampleCount` and values over 20 are tallied in a `highSampleCount`. So we count samples that are out of bounds.

  - The global min and global max values are stored, so that the real min/max are reported.

  - When computing percentiles, the percentage is translated into a sample number. which is effectively the `ceil(pct * number of samples)`. We then find out which bucket the sample is in and report the maximum possible value for that bucket. Since we have the global maximum, we clamp this to the global maximum.

  - The end result is the ability to say `x%` of samples were less than or equal to `y`. There is no interpolation of buckets and we don't use the midpoint of the bucket as this could end up reporting latency that is lower that the true max latency observed in the bucket. It is possible that we could report latency that is higher, but at least this means something (i.e. it is an upper bound for a percentage of samples, even if it's not the minimum upper bound). It will never be more than the bucket width of over-reporting.

 - The intention is to try this with all values between 1 and 60000, so the percentiles will be 100% accurate to the millisecond if all requests complete within 60s and we don't have issues with clock skew reporting negative latency.

This is just a simple histogram, but I thought it important to specify exactly what it means so we can reason about it.
