### PR TITLE
Improved Cleanup

### DIFF
--- a/ably/fanout_task.go
+++ b/ably/fanout_task.go
@@ -38,8 +38,10 @@ func fanOutTask(testConfig TestConfig) {
 	select {
 	case err := <-errorChannel:
 		log.Println(err)
+		client.Close()
 		return
 	case <-ctx.Done():
+		client.Close()
 		return
 	}
 }


### PR DESCRIPTION
Defers are not reliably cleaning up, so 'close' has to be called
manually.