### PR TITLE
Sharded Task - Call WaitGroup add before calling done

### DIFF
--- a/ably/sharded_task.go
+++ b/ably/sharded_task.go
@@ -79,6 +79,7 @@ func shardedPublisherTask(testConfig TestConfig) {
 		delay := i % testConfig.PublishInterval
 
 		log.Info("starting publisher", "num", i+1, "channel", channelName, "delay", delay)
+		wg.Add(1)
 		go publishOnInterval(ctx, testConfig, channel, delay, errorChannel, &wg)
 	}
 


### PR DESCRIPTION
If done is called without first calling add, an exception is thrown as
the WaitGroup counter cannot be negative.