### PR TITLE
Refactor tasks to be independent of the system under test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,6 @@ WORKDIR /opt/ably
 
 USER ably
 
-COPY --from=builder /opt/ably/ably-boomer /opt/ably/ably-boomer
+COPY --from=builder /opt/ably/bin/ably-boomer /opt/ably/ably-boomer
 
 ENTRYPOINT ["./ably-boomer"]

--- a/cmd/ably-boomer/flags.go
+++ b/cmd/ably-boomer/flags.go
@@ -14,12 +14,6 @@ var (
 		EnvVars: []string{"ABLY_API_KEY"},
 		Usage:   "The API key to use.",
 	}
-	channelNameFlag = &cli.StringFlag{
-		Name:    "channel-name",
-		EnvVars: []string{"ABLY_CHANNEL_NAME"},
-		Value:   "test_channel",
-		Usage:   "The name of the channel to use.",
-	}
 	publishIntervalFlag = &cli.IntFlag{
 		Name:    "publish-interval",
 		EnvVars: []string{"ABLY_PUBLISH_INTERVAL"},

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,8 @@ require (
 	github.com/r3labs/sse v0.0.0-20200828202401-10175c338a0a
 	github.com/urfave/cli/v2 v2.2.0
 	github.com/zeromq/goczmq v4.1.0+incompatible // indirect
+	go.uber.org/atomic v1.6.0
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/text v0.3.2 // indirect
 	gopkg.in/yaml.v2 v2.2.4 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -100,6 +100,7 @@ github.com/zeromq/goczmq v4.1.0+incompatible/go.mod h1:1uZybAJoSRCvZMH2rZxEwWBSm
 github.com/zeromq/gomq v0.0.0-20181008000130-95dc37dee5c4 h1:8hXkNWTNoOlOSbicfhYpCczsb6nQpDCiVryL+6lNMbY=
 github.com/zeromq/gomq v0.0.0-20181008000130-95dc37dee5c4/go.mod h1:SkCxcSQ7BQEA9FvDzbj+3hV6EMhSywyxWnHwUXVIyLY=
 go.etcd.io/etcd v3.3.22+incompatible/go.mod h1:yaeTdrJi5lOmYerz05bd8+V7KubZs8YSFZfzsF9A6aI=
+go.uber.org/atomic v1.6.0 h1:Ezj3JGmsOnG1MoRWQkPBsKLe9DwWD9QeXzTRzzldNVk=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/multierr v1.5.0/go.mod h1:FeouvMocqHpRaaGuG9EjoKcStLC43Zu/fmqdUMPcKYU=
 go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee/go.mod h1:vJERXedbb3MVM5f9Ejo0C68/HhF8uaILCdgjnY+goOA=
@@ -126,6 +127,7 @@ golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/tasks/ably/ably.go
+++ b/tasks/ably/ably.go
@@ -2,257 +2,91 @@ package ably
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"io"
-	"math/rand"
-	"net/url"
-	"regexp"
-	"strconv"
-	"sync"
-	"time"
 
-	"github.com/ably-forks/boomer"
+	"github.com/ably/ably-boomer/tasks"
 	"github.com/ably/ably-go/ably"
-	ablyrpc "github.com/ably/ably-go/ably/proto"
+	"github.com/ably/ably-go/ably/proto"
 	"github.com/inconshreveable/log15"
-	"github.com/r3labs/sse"
-	"golang.org/x/sync/errgroup"
 )
 
-// Conf is the task's configuration.
-type Conf struct {
-	Logger           log15.Logger
-	APIKey           string
-	Env              string
-	ChannelName      string
-	NumChannels      int
-	MsgDataLength    int
-	SSESubscriber    bool
-	NumSubscriptions int
-	PublishInterval  int
-}
-
-// Task contains all data required to run an Ably Runtime task.
-type Task struct {
-	conf                   Conf
-	letters                []rune
-	userCounter            int
-	userMutex              sync.Mutex
-	errorMsgTimestampRegex *regexp.Regexp
-}
-
-// NewTask returns a new Ably Runtime task.
-func NewTask(conf Conf) *Task {
-	return &Task{
-		conf:                   conf,
-		letters:                []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"),
-		errorMsgTimestampRegex: regexp.MustCompile(`tamp=[0-9]+`),
-	}
-}
-
-// Run starts the task.
-func (t *Task) Run() {
-	log := t.conf.Logger
-	log.Info(
-		"starting task",
-		"env", t.conf.Env,
-		"num-channels", t.conf.NumChannels,
-		"subs-per-channel", t.conf.NumSubscriptions,
-		"publish-interval", t.conf.PublishInterval,
-	)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	boomer.Events.Subscribe("boomer:stop", cancel)
-
-	errGroup, ctx := errgroup.WithContext(ctx)
-
-	log.Info("creating realtime connection")
-	client, err := newAblyClient(t.conf.APIKey, t.conf.Env)
-	if err != nil {
-		log.Error("error creating realtime connection", "err", err)
-
-		errMsg := t.errorMsgTimestampRegex.ReplaceAllString(err.Error(), "tamp=<timestamp>")
-
-		boomer.RecordFailure("ably", "subscribe", 0, errMsg)
-		return
-	}
-	defer client.Close()
-
-	t.userMutex.Lock()
-	t.userCounter++
-	userNumber := t.userCounter
-	t.userMutex.Unlock()
-
-	shardedChannelName := generateChannelName(t.conf.NumChannels, userNumber)
-
-	shardedChannel := client.Channels.Get(shardedChannelName)
-	defer shardedChannel.Close()
-
-	log.Info("creating sharded channel subscriber", "name", shardedChannelName)
-	shardedSub, err := shardedChannel.Subscribe()
-	if err != nil {
-		log.Error("error creating sharded channel subscriber", "name", shardedChannelName, "err", err)
-
-		errMsg := t.errorMsgTimestampRegex.ReplaceAllString(err.Error(), "tamp=<timestamp>")
-
-		boomer.RecordFailure("ably", "subscribe", 0, errMsg)
-		return
-	}
-
-	errGroup.Go(func() error {
-		return t.reportSubscriptionToLocust(ctx, shardedSub, client.Connection, log.New("channel", shardedChannelName))
-	})
-
-	personalChannelName := t.randomString(100)
-	personalChannel := client.Channels.Get(personalChannelName)
-	defer personalChannel.Close()
-
-	var subClients []io.Closer
-	log.Info("creating personal subscribers", "channel", personalChannelName, "count", t.conf.NumSubscriptions)
-	if t.conf.SSESubscriber {
-		var err error
-		if subClients, err = t.createSSESubscribers(ctx, personalChannelName, errGroup); err != nil {
-			log.Error("creating sse subscribers", "err", err)
-			boomer.RecordFailure("ably", "subscribe", 0, err.Error())
+// TaskFn creates an Ably task to run with boomer.
+func TaskFn(log log15.Logger, conf tasks.Conf) func() {
+	return func() {
+		f, err := newFactory(conf)
+		if err != nil {
+			log.Crit("connecting to realtime", "err", err)
 			return
 		}
-	} else {
-		var err error
-		if subClients, err = t.createAblySubscribers(ctx, personalChannelName, errGroup); err != nil {
-			log.Error("creating subscribers", "err", err)
-			boomer.RecordFailure("ably", "subscribe", 0, err.Error())
-			return
+		defer f.Close()
+
+		var sf tasks.SubscriberFactory = f
+		if conf.SSESubscriber {
+			sf = newSSESubscriberFactory(conf)
 		}
+
+		tasks.NewTask(log, conf, sf, f).Run()
 	}
-	defer func() {
-		for _, subClient := range subClients {
-			subClient.Close()
-		}
-	}()
-
-	log.Info("creating publishers", "count", t.conf.NumChannels)
-	for i := 0; i < t.conf.NumChannels; i++ {
-		channelName := generateChannelName(t.conf.NumChannels, i)
-
-		channel := client.Channels.Get(channelName)
-		defer channel.Close()
-
-		delay := i % t.conf.PublishInterval
-
-		log.Info("starting publisher", "num", i+1, "channel", channelName, "delay", delay)
-
-		errGroup.Go(func() error {
-			return t.publishOnInterval(ctx, t.conf.PublishInterval, t.conf.MsgDataLength, channel, delay, log)
-		})
-	}
-
-	err = errGroup.Wait()
-	if err != nil && err != context.Canceled {
-		log.Error("error from subscriber or publisher goroutine", "err", err)
-		return
-	}
-
-	log.Info("task context done, cleaning up")
 }
 
-type wrappedSSEClient struct {
-	*sse.Client
-	cancel context.CancelFunc
+type factory struct {
+	*ably.RealtimeClient
 }
 
-func (w wrappedSSEClient) Close() error {
-	w.cancel()
+func newFactory(conf tasks.Conf) (*factory, error) {
+	c, err := newAblyClient(conf.APIKey, conf.Env)
+	if err != nil {
+		return nil, err
+	}
+	return &factory{RealtimeClient: c}, nil
+}
+
+func (f *factory) NewPublisher(ctx context.Context, channelName string) (tasks.Publisher, error) {
+	p := &pubSub{c: f.Channels.Get(channelName)}
+	r, err := p.c.Attach()
+	if err != nil {
+		return nil, fmt.Errorf("attaching to %s: %w", channelName, err)
+	}
+	if err := r.Wait(); err != nil {
+		return nil, fmt.Errorf("waiting to attach to %s: %w", channelName, err)
+	}
+	return p, nil
+}
+
+func (f *factory) NewSubscriber(ctx context.Context, channelName string) (tasks.Subscriber, error) {
+	return &pubSub{c: f.Channels.Get(channelName)}, nil
+}
+
+type pubSub struct {
+	c *ably.RealtimeChannel
+}
+
+func (ps *pubSub) Publish(_ context.Context, msg *proto.Message) error {
+	r, err := ps.c.PublishAll([]*proto.Message{msg})
+	if err != nil {
+		return fmt.Errorf("publishing: %w", err)
+	}
+	if err := r.Wait(); err != nil {
+		return fmt.Errorf("waiting for ack: %w", err)
+	}
 	return nil
 }
 
-func (t *Task) createSSESubscribers(ctx context.Context, channelName string, errGroup *errgroup.Group) ([]io.Closer, error) {
-	log := t.conf.Logger
-	subClients := make([]io.Closer, 0, t.conf.NumSubscriptions)
-	for i := 0; i < t.conf.NumSubscriptions; i++ {
+func (ps *pubSub) Subscribe(ctx context.Context, msgHandler func(msg *proto.Message)) error {
+	sub, err := ps.c.Subscribe()
+	if err != nil {
+		return fmt.Errorf("subscribing: %w", err)
+	}
+	defer sub.Close()
+
+	for {
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
-		default:
-			i := i
-			ctx, cancel := context.WithCancel(ctx)
-			url := url.URL{
-				Scheme:   "https",
-				Host:     "realtime.ably.io",
-				Path:     "/sse",
-				RawQuery: "channels=" + channelName + "&v=1.1&key=" + t.conf.APIKey,
-			}
-			if t.conf.Env != "" && t.conf.Env != "production" {
-				url.Host = t.conf.Env + "-" + url.Host
-			}
-			log.Info("creating subscriber sse connection", "num", i+1, "url", url)
-			subClient := sse.NewClient(url.String())
-			subClients = append(subClients, wrappedSSEClient{Client: subClient, cancel: cancel})
-
-			errGroup.Go(func() error {
-				if err := subClient.SubscribeWithContext(ctx, "", func(msg *sse.Event) {
-					if len(msg.Data) == 0 {
-						// just ID message
-						return
-					}
-					m := &ablyrpc.Message{}
-					if err := m.UnmarshalJSON(msg.Data); err != nil {
-						log.Error("unmarshalling message", "err", err)
-						boomer.RecordFailure("ably", "subscribe", 0, err.Error())
-					}
-					validateMsg(m, log)
-				}); err != nil {
-					if ctx.Err() != nil {
-						return nil
-					}
-					log.Error("subscribing", "err", err, "num", i+1)
-					boomer.RecordFailure("ably", "subscribe", 0, err.Error())
-					return err
-				}
-				return nil
-			})
+			return nil
+		case msg := <-sub.MessageChannel():
+			msgHandler(msg)
 		}
 	}
-	return subClients, nil
-}
-
-func (t *Task) createAblySubscribers(ctx context.Context, channelName string, errGroup *errgroup.Group) ([]io.Closer, error) {
-	log := t.conf.Logger
-	subClients := make([]io.Closer, 0, t.conf.NumSubscriptions)
-	for i := 0; i < t.conf.NumSubscriptions; i++ {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		default:
-			log.Info("creating subscriber realtime connection", "num", i+1)
-			subClient, err := newAblyClient(t.conf.APIKey, t.conf.Env)
-			if err != nil {
-				subClient.Close()
-				return nil, fmt.Errorf("creating  %dth subscriber; %w", i+1, err)
-			}
-
-			channel := subClient.Channels.Get(channelName)
-
-			log.Info("creating subscriber", "num", i+1, "channel", channelName)
-			sub, err := channel.Subscribe()
-			if err != nil {
-				subClient.Close()
-				return nil, fmt.Errorf("subscribing to %dth channel; %w", i+1, err)
-			}
-
-			errGroup.Go(func() error {
-				return t.reportSubscriptionToLocust(ctx, sub, subClient.Connection, log.New("channel", channelName))
-			})
-			subClients = append(subClients, subClient)
-		}
-	}
-	return subClients, nil
-}
-
-func generateChannelName(numChannels, number int) string {
-	return "test-channel-" + strconv.Itoa(number%numChannels)
 }
 
 func newAblyClient(apiKey, env string) (*ably.RealtimeClient, error) {
@@ -260,124 +94,4 @@ func newAblyClient(apiKey, env string) (*ably.RealtimeClient, error) {
 	options.Environment = env
 
 	return ably.NewRealtimeClient(options)
-}
-
-func millisecondTimestamp() int64 {
-	nanos := time.Now().UnixNano()
-	millis := nanos / int64(time.Millisecond)
-	return millis
-}
-
-func (t *Task) randomString(length int) string {
-	b := make([]rune, length)
-	for i := range b {
-		b[i] = t.letters[rand.Intn(len(t.letters))]
-	}
-	return string(b)
-}
-
-func (t *Task) publishOnInterval(
-	ctx context.Context,
-	publishInterval,
-	msgDataLength int,
-	channel *ably.RealtimeChannel,
-	delay int,
-	log log15.Logger,
-) error {
-	log = log.New("channel", channel.Name)
-	log.Info("creating publisher", "period", publishInterval)
-
-	log.Info("introducing random delay before starting to publish", "seconds", delay)
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-time.After(time.Duration(delay) * time.Second):
-	}
-	log.Info("continuing after random delay")
-
-	ticker := time.NewTicker(time.Duration(publishInterval) * time.Second)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
-			data := t.randomString(msgDataLength)
-			timePublished := strconv.FormatInt(millisecondTimestamp(), 10)
-
-			log.Info("publishing message", "size", len(data))
-			_, err := channel.Publish(timePublished, data)
-			if err != nil {
-				log.Error("error publishing message", "err", err)
-				boomer.RecordFailure("ably", "publish", 0, err.Error())
-				return err
-			}
-
-			boomer.RecordSuccess("ably", "publish", 0, 0)
-		case <-ctx.Done():
-			return ctx.Err()
-		}
-	}
-}
-
-func (t *Task) reportSubscriptionToLocust(
-	ctx context.Context,
-	sub *ably.Subscription,
-	conn *ably.Conn,
-	log log15.Logger,
-) error {
-	connectionStateChannel := make(chan ably.State)
-	conn.On(connectionStateChannel)
-
-	var lastDisconnectTime int64 = 0
-
-	for {
-		select {
-		case connState, ok := <-connectionStateChannel:
-			if !ok {
-				log.Warn("connection state channel closed", "id", conn.ID())
-				return errors.New("connection state channel closed")
-			}
-
-			log.Info(
-				"connection state changed",
-				"id", conn.ID(),
-				"key", conn.Key(),
-				"state", connState.State,
-				"err", connState.Err,
-			)
-
-			if connState.State == ably.StateConnDisconnected {
-				lastDisconnectTime = millisecondTimestamp()
-			} else if connState.State == ably.StateConnConnected && lastDisconnectTime != 0 {
-				timeDisconnected := millisecondTimestamp() - lastDisconnectTime
-
-				log.Info("reporting reconnect time", "id", conn.ID(), "duration", timeDisconnected)
-				boomer.RecordSuccess("ably", "reconnect", timeDisconnected, 0)
-			}
-		case <-ctx.Done():
-			log.Info("subscriber context done", "id", conn.ID())
-			return ctx.Err()
-		case msg, ok := <-sub.MessageChannel():
-			if !ok {
-				log.Warn("subscriber message channel closed", "id", conn.ID())
-				return errors.New("subscriber message channel closed")
-			}
-			validateMsg(msg, log)
-		}
-	}
-}
-
-func validateMsg(msg *ablyrpc.Message, log log15.Logger) {
-	timePublished, err := strconv.ParseInt(msg.Name, 10, 64)
-	if err != nil {
-		log.Error("error parsing message name as timestamp", "err", err)
-		boomer.RecordFailure("ably", "subscribe", 0, err.Error())
-		return
-	}
-
-	timeElapsed := millisecondTimestamp() - timePublished
-	bytes := len(fmt.Sprint(msg.Data))
-
-	log.Info("received message", "size", bytes, "latency", timeElapsed)
-	boomer.RecordSuccess("ably", "subscribe", timeElapsed, int64(bytes))
 }

--- a/tasks/ably/sse.go
+++ b/tasks/ably/sse.go
@@ -1,0 +1,57 @@
+package ably
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/ably/ably-boomer/tasks"
+	"github.com/ably/ably-go/ably/proto"
+	"github.com/r3labs/sse"
+)
+
+type wrappedSSEClient struct {
+	*sse.Client
+}
+
+func (wc *wrappedSSEClient) Subscribe(ctx context.Context, msgHandler func(message *proto.Message)) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	var innerErr error
+	outerErr := wc.SubscribeWithContext(ctx, "", func(msg *sse.Event) {
+		m := &proto.Message{}
+		if innerErr = m.UnmarshalJSON(msg.Data); innerErr != nil {
+			cancel()
+			return
+		}
+		msgHandler(m)
+	})
+	if innerErr != nil {
+		return fmt.Errorf("unmarshalling sse event: %w", innerErr)
+	}
+	if outerErr != nil && ctx.Err() == nil {
+		return outerErr
+	}
+	return nil
+}
+
+type sseSubscriberFactory struct {
+	conf tasks.Conf
+}
+
+func newSSESubscriberFactory(conf tasks.Conf) *sseSubscriberFactory {
+	return &sseSubscriberFactory{conf}
+}
+
+func (s *sseSubscriberFactory) NewSubscriber(ctx context.Context, channelName string) (tasks.Subscriber, error) {
+	url := url.URL{
+		Scheme:   "https",
+		Host:     "realtime.ably.io",
+		Path:     "/sse",
+		RawQuery: "channels=" + channelName + "&v=1.1&key=" + s.conf.APIKey,
+	}
+	if s.conf.Env != "" && s.conf.Env != "production" {
+		url.Host = s.conf.Env + "-" + url.Host
+	}
+	return &wrappedSSEClient{Client: sse.NewClient(url.String())}, nil
+}

--- a/tasks/task.go
+++ b/tasks/task.go
@@ -1,0 +1,231 @@
+package tasks
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"strconv"
+	"time"
+
+	"github.com/ably-forks/boomer"
+	"github.com/ably/ably-go/ably/proto"
+	"github.com/inconshreveable/log15"
+	"go.uber.org/atomic"
+	"golang.org/x/sync/errgroup"
+)
+
+var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+// Conf is the task's configuration.
+type Conf struct {
+	APIKey           string
+	Env              string
+	NumChannels      int
+	MsgDataLength    int
+	SSESubscriber    bool
+	NumSubscriptions int
+	PublishInterval  int
+}
+
+// Publisher represents something that publishes data to a channel or stream.
+type Publisher interface {
+	// Publish publishes data to a channel or stream that could be subscribed to.
+	Publish(ctx context.Context, message *proto.Message) error
+}
+
+// PublisherFactory creates Publishers
+type PublisherFactory interface {
+	// NewPublisher creates a Publisher to a channel
+	NewPublisher(ctx context.Context, channelName string) (Publisher, error)
+}
+
+// Subscriber represents something that subscribes to messages on a channel or stream.
+type Subscriber interface {
+	// Subscribe to messages. Messages are presented to the given handler. The call is expected
+	// to be blocking and should be made with a cancelable context to end the call. Any errors on
+	// the underlying implementation will be returned by the function and the subscription is assumed
+	// to be terminated.
+	Subscribe(ctx context.Context, msgHandler func(message *proto.Message)) error
+}
+
+// SubscriberFactory creates Subscribers
+type SubscriberFactory interface {
+	// NewSubscriber creates a Subscriber to a channel or stream.
+	NewSubscriber(ctx context.Context, channelName string) (Subscriber, error)
+}
+
+// Task is a performance job that runs a collection of generic publishers and subscribers.
+type Task struct {
+	conf        Conf
+	userCounter atomic.Int64
+	taskID      int
+	subF        SubscriberFactory
+	pubF        PublisherFactory
+
+	log log15.Logger
+}
+
+// NewTask returns a new task.
+func NewTask(log log15.Logger, conf Conf, subF SubscriberFactory, pubf PublisherFactory) *Task {
+	return &Task{
+		conf:   conf,
+		taskID: rand.Int(),
+		subF:   subF,
+		pubF:   pubf,
+		log:    log,
+	}
+}
+
+// Run starts the task.
+func (t *Task) Run() {
+	log := t.log
+	log.Info(
+		"starting task",
+		"num-channels", t.conf.NumChannels,
+		"subs-per-stream", t.conf.NumSubscriptions,
+		"publish-interval", t.conf.PublishInterval,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	boomer.Events.Subscribe("boomer:stop", cancel)
+
+	errGroup, ctx := errgroup.WithContext(ctx)
+
+	t.userCounter.Add(1)
+
+	if err := t.shardedLoad(ctx, errGroup); err != nil {
+		log.Error("starting sharded load", "err", err)
+		return
+	}
+
+	if err := t.personalLoad(ctx, errGroup); err != nil {
+		log.Error("starting personal load", "err", err)
+		return
+	}
+
+	if err := errGroup.Wait(); err != nil {
+		log.Error("terminal failure, shutting down", "err", err)
+		return
+	}
+
+	log.Info("task complete")
+}
+
+func (t *Task) shardedLoad(ctx context.Context, errGroup *errgroup.Group) error {
+	shardedChannelName := t.generateStreamName(int64(t.conf.NumChannels), t.userCounter.Load())
+
+	t.log.Info("creating sharded subscriber", "name", shardedChannelName)
+	sub, err := t.subF.NewSubscriber(ctx, shardedChannelName)
+	if err != nil {
+		t.log.Error("creating sharded subscriber", "name", shardedChannelName, "err", err)
+		boomer.RecordFailure("subscribe", "create sharded subscriber", 0, err.Error())
+		return err
+	}
+
+	errGroup.Go(func() error {
+		if err := sub.Subscribe(ctx, t.validateMsg); err != nil {
+			t.log.Error("subscribing shard", "name", shardedChannelName, "err", err)
+			boomer.RecordFailure("subscribe", "sharded subscriber", 0, err.Error())
+			return err
+		}
+		return nil
+	})
+	return nil
+}
+
+func (t *Task) personalLoad(ctx context.Context, errGroup *errgroup.Group) error {
+	personalChannelName := RandomString(100)
+	t.log.Info("creating personal subscribers", "channel", personalChannelName, "count", t.conf.NumSubscriptions)
+	for i := 0; i < t.conf.NumSubscriptions; i++ {
+		i := i
+		sub, err := t.subF.NewSubscriber(ctx, personalChannelName)
+		if err != nil {
+			t.log.Error("creating personal subscriber", "name", personalChannelName, "err", err)
+			boomer.RecordFailure("subscribe", "create personal subscriber", 0, err.Error())
+			return err
+		}
+		errGroup.Go(func() error {
+			if err := sub.Subscribe(ctx, t.validateMsg); err != nil {
+				t.log.Error("personal subscriber", "name", personalChannelName, "index", i, "err", err)
+				boomer.RecordFailure("subscribe", "personal subscriber", 0, err.Error())
+				return err
+			}
+			return nil
+		})
+	}
+
+	t.log.Info("creating publisher")
+	errGroup.Go(func() error {
+		return t.publishLoop(ctx, personalChannelName, t.conf.PublishInterval, t.conf.MsgDataLength)
+	})
+	return nil
+}
+
+func (t *Task) validateMsg(msg *proto.Message) {
+	timePublished, err := strconv.ParseInt(msg.Name, 10, 64)
+	if err != nil {
+		t.log.Error("error parsing message name as timestamp", "err", err)
+		boomer.RecordFailure("subscribe", "parsing", 0, err.Error())
+		return
+	}
+
+	timeElapsed := MillisecondTimestamp() - timePublished
+	bytes := len(fmt.Sprint(msg.Data))
+
+	t.log.Info("received message", "size", bytes, "latency", timeElapsed)
+	boomer.RecordSuccess("subscribe", "message", timeElapsed, int64(bytes))
+}
+
+func (t *Task) publishLoop(ctx context.Context, channelName string, interval, msgDataLength int) error {
+	log := t.log.New("channel", channelName)
+	log.Info("creating publisher", "period", interval)
+	p, err := t.pubF.NewPublisher(ctx, channelName)
+	if err != nil {
+		log.Error("creating publisher", "err", err)
+		boomer.RecordFailure("publish", "create publisher", 0, err.Error())
+		return err
+	}
+
+	ticker := time.NewTicker(time.Duration(interval) * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			msg := &proto.Message{
+				Name: strconv.FormatInt(MillisecondTimestamp(), 10),
+				Data: RandomString(msgDataLength),
+			}
+
+			log.Info("publishing message", "size", msgDataLength)
+			if err := p.Publish(ctx, msg); err != nil {
+				log.Error("publishing message", "err", err)
+				boomer.RecordFailure("publish", "publishing", 0, err.Error())
+				return err
+			}
+			boomer.RecordSuccess("publish", "message", 0, 0)
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+func (t *Task) generateStreamName(numStreams, number int64) string {
+	return fmt.Sprintf("task-%v-%v", t.taskID, number%numStreams)
+}
+
+// MillisecondTimestamp converts the current time in milliseconds.
+func MillisecondTimestamp() int64 {
+	nanos := time.Now().UnixNano()
+	return nanos / int64(time.Millisecond)
+}
+
+// RandomString creates a random string of given length.
+func RandomString(length int) string {
+	b := make([]rune, length)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}


### PR DESCRIPTION
I've refactored the task so it can be reused for our internal tests and returned the functionality to what it was when in the composite test. This is:
- sharded subscribers: multiple subscribers across boomer instances subscribing to a small number of channels
- personal load: each boomer creates multiple subscribers to a channel and periodically publishes to it.

Taking this approach should mean that whatever the system we're testing we can have a common language of the type of test we're running.