### PR TITLE
Bump ably-go to feature/conn-open-failures-rtn14 (80f6c2a)

### DIFF
--- a/ably/ably_client.go
+++ b/ably/ably_client.go
@@ -10,11 +10,11 @@ import (
 // to avoid transient connection errors being reported as failures.
 //
 // TODO: remove the retries once handled by ably-go.
-func newAblyClient(testConfig TestConfig) (client *ably.RealtimeClient, err error) {
+func newAblyClient(testConfig TestConfig) (client *ably.Realtime, err error) {
 	options := ably.NewClientOptions(testConfig.APIKey)
-	options.Environment = testConfig.Env
+	options.Environment(testConfig.Env)
 
-	client, err = ably.NewRealtimeClient(options)
+	client, err = ably.NewRealtime(options)
 	if err == nil {
 		return
 	}
@@ -30,7 +30,7 @@ func newAblyClient(testConfig TestConfig) (client *ably.RealtimeClient, err erro
 	}
 	for _, delay := range delays {
 		time.Sleep(delay)
-		client, err = ably.NewRealtimeClient(options)
+		client, err = ably.NewRealtime(options)
 		if err == nil {
 			return
 		}

--- a/ably/ably_client.go
+++ b/ably/ably_client.go
@@ -6,8 +6,9 @@ import (
 
 // newAblyClient creates a new Ably realtime client.
 func newAblyClient(testConfig TestConfig) (*ably.Realtime, error) {
-	options := ably.NewClientOptions(testConfig.APIKey)
-	options.Environment(testConfig.Env)
+	options := ably.ClientOptions{}.
+		Key(testConfig.APIKey).
+		Environment(testConfig.Env)
 
 	return ably.NewRealtime(options)
 }

--- a/ably/ably_client.go
+++ b/ably/ably_client.go
@@ -1,43 +1,13 @@
 package main
 
 import (
-	"time"
-
 	"github.com/ably/ably-go/ably"
 )
 
-// newAblyClient creates a new Ably realtime client, making multiple attempts
-// to avoid transient connection errors being reported as failures.
-//
-// TODO: remove the retries once handled by ably-go.
-func newAblyClient(testConfig TestConfig) (client *ably.Realtime, err error) {
+// newAblyClient creates a new Ably realtime client.
+func newAblyClient(testConfig TestConfig) (*ably.Realtime, error) {
 	options := ably.NewClientOptions(testConfig.APIKey)
 	options.Environment(testConfig.Env)
 
-	client, err = ably.NewRealtime(options)
-	if err == nil {
-		return
-	}
-	log.Warn("error creating client, will retry", "err", err)
-
-	// retry with a backoff
-	delays := []time.Duration{
-		100 * time.Millisecond,
-		1 * time.Second,
-		5 * time.Second,
-		10 * time.Second,
-		10 * time.Second,
-	}
-	for _, delay := range delays {
-		time.Sleep(delay)
-		client, err = ably.NewRealtime(options)
-		if err == nil {
-			return
-		}
-		// ideally we'd only retry recoverable errors, but that really
-		// ought to be done in ably-go, so let's defer to when that's
-		// implemented in ably-go
-		log.Warn("error creating ably client in retry loop", "err", err)
-	}
-	return
+	return ably.NewRealtime(options)
 }

--- a/ably/ably_client.go
+++ b/ably/ably_client.go
@@ -4,11 +4,33 @@ import (
 	"github.com/ably/ably-go/ably"
 )
 
-// newAblyClient creates a new Ably realtime client.
+// newAblyClient creates a new Ably realtime client and waits for it to connect.
 func newAblyClient(testConfig TestConfig) (*ably.Realtime, error) {
 	options := ably.ClientOptions{}.
 		Key(testConfig.APIKey).
-		Environment(testConfig.Env)
+		Environment(testConfig.Env).
+		AutoConnect(false)
 
-	return ably.NewRealtime(options)
+	client, err := ably.NewRealtime(options)
+	if err != nil {
+		return nil, err
+	}
+
+	// wait for either a CONNECTED or FAILED event
+	errC := make(chan error)
+	unsub := client.Connection.OnAll(func(state ably.ConnectionStateChange) {
+		log.Info("got connection state change", "event", state.Event, "reason", state.Reason)
+		switch state.Event {
+		case ably.ConnectionEventConnected:
+			errC <- nil
+		case ably.ConnectionEventFailed:
+			errC <- state.Reason
+		}
+	})
+	defer unsub()
+	client.Connect()
+	if err := <-errC; err != nil {
+		return nil, err
+	}
+	return client, nil
 }

--- a/ably/composite_task.go
+++ b/ably/composite_task.go
@@ -3,9 +3,9 @@ package main
 import (
 	"context"
 	"math/rand"
+	"regexp"
 	"strconv"
 	"sync"
-	"regexp"
 
 	"github.com/ably-forks/boomer"
 )
@@ -48,7 +48,6 @@ func compositeTask(testConfig TestConfig) {
 	shardedChannelName := generateShardedChannelName(testConfig, userNumber)
 
 	shardedChannel := client.Channels.Get(shardedChannelName)
-	defer shardedChannel.Close()
 
 	log.Info("creating sharded channel subscriber", "name", shardedChannelName)
 	shardedSub, err := shardedChannel.Subscribe()
@@ -66,7 +65,6 @@ func compositeTask(testConfig TestConfig) {
 
 	personalChannelName := randomString(100)
 	personalChannel := client.Channels.Get(personalChannelName)
-	defer personalChannel.Close()
 
 	log.Info("creating personal subscribers", "channel", personalChannelName, "count", testConfig.NumSubscriptions)
 	for i := 0; i < testConfig.NumSubscriptions; i++ {

--- a/ably/fanout_task.go
+++ b/ably/fanout_task.go
@@ -19,7 +19,6 @@ func fanOutTask(testConfig TestConfig) {
 	defer client.Close()
 
 	channel := client.Channels.Get(testConfig.ChannelName)
-	defer channel.Close()
 
 	log.Info("creating subscriber", "name", testConfig.ChannelName)
 	sub, err := channel.Subscribe()

--- a/ably/personal_task.go
+++ b/ably/personal_task.go
@@ -46,7 +46,7 @@ func personalTask(testConfig TestConfig) {
 
 	channelName := randomString(channelNameLength)
 
-	subClients := []ably.RealtimeClient{}
+	subClients := []ably.Realtime{}
 
 	log.Info("creating subscribers", "channel", channelName, "count", testConfig.NumSubscriptions)
 	for i := 0; i < testConfig.NumSubscriptions; i++ {
@@ -66,7 +66,6 @@ func personalTask(testConfig TestConfig) {
 			subClients = append(subClients, *subClient)
 
 			channel := subClient.Channels.Get(channelName)
-			defer channel.Close()
 
 			log.Info("creating subscriber", "num", i+1, "channel", channelName)
 			sub, err := channel.Subscribe()
@@ -92,7 +91,6 @@ func personalTask(testConfig TestConfig) {
 	defer publishClient.Close()
 
 	channel := publishClient.Channels.Get(channelName)
-	defer channel.Close()
 
 	cleanup := func() {
 		publishClient.Close()

--- a/ably/sharded_task.go
+++ b/ably/sharded_task.go
@@ -87,7 +87,6 @@ func shardedPublisherTask(testConfig TestConfig) {
 		channelName := generateChannelName(testConfig, i)
 
 		channel := client.Channels.Get(channelName)
-		defer channel.Close()
 
 		delay := i * testConfig.PublishInterval / testConfig.NumChannels
 
@@ -117,7 +116,7 @@ func shardedSubscriberTask(testConfig TestConfig) {
 	errorChannel := make(chan error)
 	var wg sync.WaitGroup
 
-	clients := []ably.RealtimeClient{}
+	clients := []ably.Realtime{}
 
 	log.Info("creating subscribers", "count", testConfig.NumSubscriptions)
 	for i := 0; i < testConfig.NumSubscriptions; i++ {
@@ -139,7 +138,6 @@ func shardedSubscriberTask(testConfig TestConfig) {
 			channelName := generateChannelName(testConfig, i)
 
 			channel := client.Channels.Get(channelName)
-			defer channel.Close()
 
 			log.Info("creating subscriber", "num", i+1, "name", channelName)
 			sub, err := channel.Subscribe()

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
 	github.com/ably-forks/boomer v0.0.0-20200717132144-47e73943070d
-	github.com/ably/ably-go v1.1.6-0.20201023134633-d652167c4a75
+	github.com/ably/ably-go v1.1.6-0.20201026170008-80f6c2a0ef72
 	github.com/aws/aws-sdk-go v1.33.17
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/go-stack/stack v1.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/ably/ably-go v1.1.6-0.20200905151113-60928e378b37 h1:ULW1VSE/OFgNXqti
 github.com/ably/ably-go v1.1.6-0.20200905151113-60928e378b37/go.mod h1:bdOnFcqJrbZE7WSp1jqbdsIMBo5aMGXh98GWiiwmeZ0=
 github.com/ably/ably-go v1.1.6-0.20201023134633-d652167c4a75 h1:BG7EgRF6XVjDJ10aRinWRM3lILR8b1/Ik/v6ynRggvs=
 github.com/ably/ably-go v1.1.6-0.20201023134633-d652167c4a75/go.mod h1:bdOnFcqJrbZE7WSp1jqbdsIMBo5aMGXh98GWiiwmeZ0=
+github.com/ably/ably-go v1.1.6-0.20201026170008-80f6c2a0ef72 h1:S69FNdiA9hJzXMGcgVVS37dQ6oMpVeNHDjinAVc1ws8=
+github.com/ably/ably-go v1.1.6-0.20201026170008-80f6c2a0ef72/go.mod h1:bdOnFcqJrbZE7WSp1jqbdsIMBo5aMGXh98GWiiwmeZ0=
 github.com/andybalholm/brotli v1.0.0/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/asaskevich/EventBus v0.0.0-20200428142821-4fc0642a29f3 h1:LHEOGCi+2CooiWkQB2BlzdMVh6rdRDyt5Wflv4yzvXY=
 github.com/asaskevich/EventBus v0.0.0-20200428142821-4fc0642a29f3/go.mod h1:JS7hed4L1fj0hXcyEejnW57/7LCetXggd+vwrRnYeII=


### PR DESCRIPTION
This updates the ably-go dependency to use the majority of the 1.2 changes plus the changes from the [connection open retries PR](https://github.com/ably/ably-go/pull/172) (which right now is missing some commits from the 1.2 integration branch, but should be good enough for us to test with).