### PR TITLE
Improve push error reporting from push metachannel

### DIFF
--- a/worker_test.go
+++ b/worker_test.go
@@ -94,7 +94,7 @@ type testClient struct {
 	events chan testEvent
 }
 
-func (t *testClient) Subscribe(ctx context.Context, channel string, handler func([]byte)) error {
+func (t *testClient) Subscribe(ctx context.Context, channel string, handler func(*ably.Message)) error {
 	t.events <- testEventSubscribe
 	<-ctx.Done()
 	t.events <- testEventStop


### PR DESCRIPTION
The data published on the `[meta]log:push` is not JSON but `map[string]interface{}`, so this PR parses this and records a Push error if one is detected.