### PR TITLE
Add push registration and subscription intervals

### DIFF
--- a/client.go
+++ b/client.go
@@ -131,7 +131,7 @@ func (a *ablyClient) Subscribe(ctx context.Context, channelName string, handler 
 
 // Publish publishes the given message to the given Ably channel.
 func (a *ablyClient) Publish(ctx context.Context, channelName string, messages []*ably.Message) error {
-	return a.Realtime.Channels.Get(channelName).PublishBatch(ctx, messages)
+	return a.Realtime.Channels.Get(channelName).PublishMultiple(ctx, messages)
 }
 
 // Enter enters the given Ably channel using the given clientID.

--- a/config/config.go
+++ b/config/config.go
@@ -79,9 +79,11 @@ type SubscriberConfig struct {
 }
 
 type SubscriberPushDeviceConfig struct {
-	Enabled            bool
-	URL                string
-	MetachannelEnabled bool
+	Enabled                    bool
+	URL                        string
+	MetachannelEnabled         bool
+	RegistrationUpdateInterval time.Duration
+	SubscriptionUpdateInterval time.Duration
 }
 
 type PublisherConfig struct {

--- a/config/flags.go
+++ b/config/flags.go
@@ -62,6 +62,20 @@ func (c *Config) Flags() []cli.Flag {
 			Destination: &c.Subscriber.PushDevice.MetachannelEnabled,
 			EnvVars:     []string{"SUBSCRIBER_PUSH_DEVICE_METACHANNEL_ENABLED"},
 		}),
+		altsrc.NewDurationFlag(&cli.DurationFlag{
+			Name:        "subscriber.push-device.registration-update-interval",
+			Usage:       "The interval between two registration updates (0 to disable)",
+			Value:       c.Subscriber.PushDevice.RegistrationUpdateInterval,
+			Destination: &c.Subscriber.PushDevice.RegistrationUpdateInterval,
+			EnvVars:     []string{"SUBSCRIBER_PUSH_DEVICE_REGISTRATION_UPDATE_INTERVAL"},
+		}),
+		altsrc.NewDurationFlag(&cli.DurationFlag{
+			Name:        "subscriber.push-device.subscription-update-interval",
+			Usage:       "The interval between two subscription updates (0 to disable)",
+			Value:       c.Subscriber.PushDevice.SubscriptionUpdateInterval,
+			Destination: &c.Subscriber.PushDevice.SubscriptionUpdateInterval,
+			EnvVars:     []string{"SUBSCRIBER_PUSH_DEVICE_SUBSCRIPTION_UPDATE_INTERVAL"},
+		}),
 		altsrc.NewBoolFlag(&cli.BoolFlag{
 			Name:        "publisher.enabled",
 			Usage:       "Run publishers",

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
-	github.com/ably/ably-go v1.2.0-apipreview.4.0.20210513173937-42f635f91571
+	github.com/ably/ably-go v1.2.0-apipreview.4.0.20210514134729-e972f86e6a30
 	github.com/asaskevich/EventBus v0.0.0-20200428142821-4fc0642a29f3 // indirect
 	github.com/aws/aws-sdk-go v1.33.17
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/ably/ably-go v1.2.0-apipreview.4.0.20210513172055-70618e507728 h1:Twx
 github.com/ably/ably-go v1.2.0-apipreview.4.0.20210513172055-70618e507728/go.mod h1:bdOnFcqJrbZE7WSp1jqbdsIMBo5aMGXh98GWiiwmeZ0=
 github.com/ably/ably-go v1.2.0-apipreview.4.0.20210513173937-42f635f91571 h1:Ym7baY9NdAxVbPTu2ugcD1ClH7ofPUstrz/OtswMd6Y=
 github.com/ably/ably-go v1.2.0-apipreview.4.0.20210513173937-42f635f91571/go.mod h1:bdOnFcqJrbZE7WSp1jqbdsIMBo5aMGXh98GWiiwmeZ0=
+github.com/ably/ably-go v1.2.0-apipreview.4.0.20210514134729-e972f86e6a30 h1:/Y5jMj/2j30HaMBrP4j2hRKZyfACwxg331cco0APKkQ=
+github.com/ably/ably-go v1.2.0-apipreview.4.0.20210514134729-e972f86e6a30/go.mod h1:bdOnFcqJrbZE7WSp1jqbdsIMBo5aMGXh98GWiiwmeZ0=
 github.com/asaskevich/EventBus v0.0.0-20200428142821-4fc0642a29f3 h1:LHEOGCi+2CooiWkQB2BlzdMVh6rdRDyt5Wflv4yzvXY=
 github.com/asaskevich/EventBus v0.0.0-20200428142821-4fc0642a29f3/go.mod h1:JS7hed4L1fj0hXcyEejnW57/7LCetXggd+vwrRnYeII=
 github.com/aws/aws-sdk-go v1.33.17 h1:vngPRchZs603qLtJH7lh2pBCDqiFxA9+9nDWJ5WYJ5A=


### PR DESCRIPTION
This adds push registration and subscription intervals. I have noticed an [issue](https://github.com/ably/ably-go/pull/314) with `ably-go` on the commit we were on previously, when a HTTP request resulted with a 204 status code (no content). I have updated `ably-go` to the latest commit on the `integration/1.2` branch and that fixed the issue but also introduced API changes.