### PR TITLE
Ably: add an option to choose channel modes

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -41,6 +41,7 @@ func Default() *Config {
 
 	conf.Ably.ConnectionTimeout = 4 * time.Second
 	conf.Ably.RequestTimeout = 10 * time.Second
+	conf.Ably.ChannelModes = "" // Use default modes.
 
 	conf.Log.Level = log15.LvlInfo.String()
 
@@ -115,6 +116,7 @@ type AblyConfig struct {
 	Environment       string
 	ConnectionTimeout time.Duration
 	RequestTimeout    time.Duration
+	ChannelModes      string
 }
 
 func (a *AblyConfig) ClientOptions() []ably.ClientOption {

--- a/config/flags.go
+++ b/config/flags.go
@@ -189,6 +189,13 @@ func (c *Config) Flags() []cli.Flag {
 			Destination: &c.Ably.RequestTimeout,
 			EnvVars:     []string{"ABLY_REQUEST_TIMEOUT"},
 		}),
+		altsrc.NewStringFlag(&cli.StringFlag{
+			Name:        "ably.channel-modes",
+			Usage:       "The Channel Modes to use (comma separated, set to empty to use the default modes) Valid modes are 'presence', 'publish', 'subscribe', and 'presenceSubscribe'",
+			Value:       c.Ably.ChannelModes,
+			Destination: &c.Ably.ChannelModes,
+			EnvVars:     []string{"ABLY_CHANNEL_MODES"},
+		}),
 		altsrc.NewPathFlag(&cli.PathFlag{
 			Name:        "perf.cpu-profile-dir",
 			Usage:       "The directory path to write the pprof cpu profile",


### PR DESCRIPTION
This adds an option to choose channel mode flags. This allows to enter presence when subscribing to a channel without subscribing to presence events.