### PR TITLE
Add subscriber reconnect interval

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -74,9 +74,10 @@ const (
 )
 
 type SubscriberConfig struct {
-	Enabled    bool
-	Channels   string
-	PushDevice SubscriberPushDeviceConfig
+	Enabled           bool
+	Channels          string
+	ReconnectInterval time.Duration
+	PushDevice        SubscriberPushDeviceConfig
 }
 
 type SubscriberPushDeviceConfig struct {

--- a/config/flags.go
+++ b/config/flags.go
@@ -41,6 +41,13 @@ func (c *Config) Flags() []cli.Flag {
 			Destination: &c.Subscriber.Channels,
 			EnvVars:     []string{"SUBSCRIBER_CHANNELS"},
 		}),
+		altsrc.NewDurationFlag(&cli.DurationFlag{
+			Name:        "subscriber.reconnect-interval",
+			Usage:       "The interval after which the subscriber should reconnect (0 to disable)",
+			Value:       c.Subscriber.ReconnectInterval,
+			Destination: &c.Subscriber.ReconnectInterval,
+			EnvVars:     []string{"SUBSCRIBER_RECONNECT_INTERVAL"},
+		}),
 		altsrc.NewBoolFlag(&cli.BoolFlag{
 			Name:        "subscriber.push-device.enabled",
 			Usage:       "Register and subscribe a push device",


### PR DESCRIPTION
This adds a `subscriber.reconnect-interval` duration flag which when set to a non-zero value causes subscribers to reconnect at the given interval.

Example config:

```
subscriber.enabled: true
subscriber.channels: fanout
subscriber.reconnect-interval: 10s
```

Each time the subscriber reconnects, it emits a `reconnect` event to Locust which can be seen on the load test dashboard:

<img width="1434" alt="Screenshot 2021-07-15 at 12 28 37" src="https://user-images.githubusercontent.com/488515/125780883-a643b261-fb0f-452e-9da5-cddf98b8df93.png">
