### PR TITLE
Bump Go and Locust versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:experimental
-FROM golang:1.14.4-alpine3.12 AS builder
+FROM golang:1.16-alpine3.13 AS builder
 
 WORKDIR /home/ablyboomer
 
@@ -12,7 +12,7 @@ RUN \
     --mount=type=cache,target=/go \
     make build
 
-FROM alpine:3.12
+FROM alpine:3.13
 
 RUN adduser -S ablyboomer
 USER ablyboomer

--- a/examples/composite/docker-compose.yml
+++ b/examples/composite/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   locust:
-    image: locustio/locust:1.4.1
+    image: locustio/locust:1.6.0
     environment:
       LOCUST_HOST: http://locust
       LOCUST_MODE_MASTER: "true"

--- a/examples/fanout/docker-compose.yml
+++ b/examples/fanout/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   locust:
-    image: locustio/locust:1.4.1
+    image: locustio/locust:1.6.0
     environment:
       LOCUST_HOST: http://locust
       LOCUST_MODE_MASTER: "true"

--- a/examples/personal/docker-compose.yml
+++ b/examples/personal/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   locust:
-    image: locustio/locust:1.4.1
+    image: locustio/locust:1.6.0
     environment:
       LOCUST_HOST: http://locust
       LOCUST_MODE_MASTER: "true"

--- a/examples/presence/docker-compose.yml
+++ b/examples/presence/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   locust:
-    image: locustio/locust:1.4.1
+    image: locustio/locust:1.6.0
     environment:
       LOCUST_HOST: http://locust
       LOCUST_MODE_MASTER: "true"

--- a/examples/push-fanout/docker-compose.yml
+++ b/examples/push-fanout/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   locust:
-    image: locustio/locust:1.4.1
+    image: locustio/locust:1.6.0
     environment:
       LOCUST_HOST: http://locust
       LOCUST_MODE_MASTER: "true"

--- a/examples/sharded/docker-compose.yml
+++ b/examples/sharded/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   locust:
-    image: locustio/locust:1.4.1
+    image: locustio/locust:1.6.0
     environment:
       LOCUST_HOST: http://locust
       LOCUST_MODE_MASTER: "true"

--- a/examples/sse/docker-compose.yml
+++ b/examples/sse/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   locust:
-    image: locustio/locust:1.4.1
+    image: locustio/locust:1.6.0
     environment:
       LOCUST_HOST: http://locust
       LOCUST_MODE_MASTER: "true"


### PR DESCRIPTION
Tested by starting a fanout load test:

```
$ make image
$ cd examples/fanout
$ docker-compose up
```

Seems to work 🙂 