### PR TITLE
Update boomer commit and locust version

### DIFF
--- a/examples/composite/docker-compose.yml
+++ b/examples/composite/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   locust:
-    image: locustio/locust:1.6.0
+    image: locustio/locust:2.4.1
     environment:
       LOCUST_HOST: http://locust
       LOCUST_MODE_MASTER: "true"

--- a/examples/fanout/docker-compose.yml
+++ b/examples/fanout/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   locust:
-    image: locustio/locust:1.6.0
+    image: locustio/locust:2.4.1
     environment:
       LOCUST_HOST: http://locust
       LOCUST_MODE_MASTER: "true"

--- a/examples/personal/docker-compose.yml
+++ b/examples/personal/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   locust:
-    image: locustio/locust:1.6.0
+    image: locustio/locust:2.4.1
     environment:
       LOCUST_HOST: http://locust
       LOCUST_MODE_MASTER: "true"

--- a/examples/presence/docker-compose.yml
+++ b/examples/presence/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   locust:
-    image: locustio/locust:1.6.0
+    image: locustio/locust:2.4.1
     environment:
       LOCUST_HOST: http://locust
       LOCUST_MODE_MASTER: "true"

--- a/examples/push-fanout/docker-compose.yml
+++ b/examples/push-fanout/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   locust:
-    image: locustio/locust:1.6.0
+    image: locustio/locust:2.4.1
     environment:
       LOCUST_HOST: http://locust
       LOCUST_MODE_MASTER: "true"

--- a/examples/sharded/docker-compose.yml
+++ b/examples/sharded/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   locust:
-    image: locustio/locust:1.6.0
+    image: locustio/locust:2.4.1
     environment:
       LOCUST_HOST: http://locust
       LOCUST_MODE_MASTER: "true"

--- a/examples/sse/docker-compose.yml
+++ b/examples/sse/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   locust:
-    image: locustio/locust:1.6.0
+    image: locustio/locust:2.4.1
     environment:
       LOCUST_HOST: http://locust
       LOCUST_MODE_MASTER: "true"

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/inconshreveable/log15 v0.0.0-20200109203555-b30bc20e4fd1
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.7 // indirect
-	github.com/myzhan/boomer v0.0.0-20210122030331-a9eddc3e0219
+	github.com/myzhan/boomer v0.0.0-20210918034300-6d5b8bc914bb
 	github.com/olekukonko/tablewriter v0.0.4 // indirect
 	github.com/r3labs/sse v0.0.0-20200828202401-10175c338a0a
 	github.com/shirou/gopsutil v2.20.5+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHX
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.7 h1:Ei8KR0497xHyKJPAv59M1dkC+rOZCMBJ+t3fZ+twI54=
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
-github.com/myzhan/boomer v0.0.0-20210122030331-a9eddc3e0219 h1:JRhXkB6ZKcexfxmKunvwj0T5r7AOGqrYpHrLNLJbER0=
-github.com/myzhan/boomer v0.0.0-20210122030331-a9eddc3e0219/go.mod h1:Ma68Td5C5EAc1M9XA7yjC/tXg9u5qviNujytnX099ZQ=
+github.com/myzhan/boomer v0.0.0-20210918034300-6d5b8bc914bb h1:jmMUYy/xtTWqmb5boUDBNbADJU7zN+TUUTkXf8jF/Ck=
+github.com/myzhan/boomer v0.0.0-20210918034300-6d5b8bc914bb/go.mod h1:Ma68Td5C5EAc1M9XA7yjC/tXg9u5qviNujytnX099ZQ=
 github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/olekukonko/tablewriter v0.0.4 h1:vHD/YYe1Wolo78koG299f7V/VAS08c6IpCLn+Ejf/w8=


### PR DESCRIPTION
* Updated the upstream github.com/myzhan/boomer which breaks
  compatibility running with locust:1.6.0
* Replaces docker-compose files locust:1.6.0 with locust:2.4.1 (all examples run ok)
* Also tested in development cluster with infrastructure updated to locust 2.4.1 (and pinning go-services)